### PR TITLE
Fix a docstring formatting typo

### DIFF
--- a/azure/functions/_http.py
+++ b/azure/functions/_http.py
@@ -132,7 +132,7 @@ class HttpRequest(_abc.HttpRequest):
     :param str method:
         HTTP request method name.
 
-    :param str url
+    :param str url:
         HTTP URL.
 
     :param dict headers:


### PR DESCRIPTION
Missing trailing `:` for the `url` parameter causes the docstring to render improperly by including `:param str url HTTP URL.` in https://docs.microsoft.com/en-us/python/api/azure-functions/azure.functions.httprequest?view=azure-python and not listing `url` as a parameter.

Closes #19 