### PR TITLE
Add Azure Pipelines support for Tests and Build

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -1,0 +1,22 @@
+# Publish azure-functions-python-library to PyPI
+
+
+trigger:
+- master
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '3.6'
+  displayName: 'Use Python 3.6'
+
+- script: |
+    pip install pytest pytest-azurepipelines
+    pytest
+  displayName: 'pytest'
+
+- script: echo "Someone with PyPI permissions would need to finish this off."
+  displayName: "Someone with PyPI permissions would need to finish this off."

--- a/.azure-pipelines/test.yml
+++ b/.azure-pipelines/test.yml
@@ -1,0 +1,41 @@
+# Test azure-functions-python-library on any push to remote repository.
+
+trigger:
+- '*'
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+strategy:
+  matrix:
+    linux_py36:
+      image: 'ubuntu-latest'
+      python.version: '3.6'
+    macos_py36:
+      image: 'macOS-latest'
+      python.version: '3.6'
+    windows_py36:
+      image: 'windows-latest'
+      python.version: '3.6'
+    linux_py37:
+      image: 'ubuntu-latest'
+      python.version: '3.7'
+    macos_py37:
+      image: 'macOS-latest'
+      python.version: '3.7'
+    windows_py37:
+      image: 'windows-latest'
+      python.version: '3.7'
+
+steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '$(python.version)'
+  displayName: 'Use Python $(python.version)'
+
+- script: |
+    pip install pytest pytest-azurepipelines
+    pytest
+  displayName: 'pytest'
+
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
+# Azure Functions Python Library
 
-# Contributing
+| Pipeline | Status                                                                                                                                                                                                                                                  |
+| -------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|     Test | [![Build Status](https://dev.azure.com/teckert0973/res/_apis/build/status/azure-functions-python-library/test.azure-functions-python-library?branchName=master)](https://dev.azure.com/teckert0973/res/_build/latest?definitionId=1&branchName=master)  |
+|   Deploy | [![Build Status](https://dev.azure.com/teckert0973/res/_apis/build/status/azure-functions-python-library/build.azure-functions-python-library?branchName=master)](https://dev.azure.com/teckert0973/res/_build/latest?definitionId=2&branchName=master) |
+
+## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us


### PR DESCRIPTION
This PR adds support for a test and build pipeline using Azure DevOps. 

The testing pipeline should work as is once Azure Pipelines support is added for the upstream repository. It will run `pytest` which will run `unittest` tests as well and publish the result across Linux, Windows, and MacOS and Python 3.6 and 3.7.

The build pipeline will need additional work. Someone with login access to PyPI for the project will need to finish off the pipeline in the Azure DevOps UI. 
