### PR TITLE
Allow cosmosdb document parameter to pass in null

### DIFF
--- a/azure/functions/cosmosdb.py
+++ b/azure/functions/cosmosdb.py
@@ -43,7 +43,8 @@ class CosmosDBConverter(meta.InConverter, meta.OutConverter,
             documents = [documents]
 
         return cdb.DocumentList(
-            (None if doc is None else cdb.Document.from_dict(doc)) for doc in documents)
+            (None if doc is None else cdb.Document.from_dict(doc))
+            for doc in documents)
 
     @classmethod
     def encode(cls, obj: typing.Any, *,

--- a/azure/functions/cosmosdb.py
+++ b/azure/functions/cosmosdb.py
@@ -20,6 +20,9 @@ class CosmosDBConverter(meta.InConverter, meta.OutConverter,
 
     @classmethod
     def decode(cls, data: meta.Datum, *, trigger_metadata) -> cdb.DocumentList:
+        if data is None or data.type is None:
+            return None
+
         data_type = data.type
 
         if data_type == 'string':
@@ -40,7 +43,7 @@ class CosmosDBConverter(meta.InConverter, meta.OutConverter,
             documents = [documents]
 
         return cdb.DocumentList(
-            cdb.Document.from_dict(doc) for doc in documents)
+            (None if doc is None else cdb.Document.from_dict(doc)) for doc in documents)
 
     @classmethod
     def encode(cls, obj: typing.Any, *,

--- a/tests/test_cosmosdb.py
+++ b/tests/test_cosmosdb.py
@@ -1,0 +1,84 @@
+import unittest
+
+import azure.functions as func
+import azure.functions.cosmosdb as cdb
+from azure.functions.meta import Datum
+
+class TestCosmosdb(unittest.TestCase):
+    def test_cosmosdb_convert_none(self):
+        result: func.DocumentList = cdb.CosmosDBConverter.decode(data=None, trigger_metadata=None)
+        self.assertIsNone(result)
+
+    def test_cosmosdb_convert_string(self):
+        datum: Datum = Datum("""
+        {
+            "id": "1",
+            "name": "awesome_name"
+        }
+        """, "string")
+        result: func.DocumentList = cdb.CosmosDBConverter.decode(data=datum, trigger_metadata=None)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['name'], 'awesome_name')
+
+    def test_cosmosdb_convert_bytes(self):
+        datum: Datum = Datum("""
+        {
+            "id": "1",
+            "name": "awesome_name"
+        }
+        """.encode(), "bytes")
+        result: func.DocumentList = cdb.CosmosDBConverter.decode(data=datum, trigger_metadata=None)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['name'], 'awesome_name')
+
+    def test_cosmosdb_convert_json(self):
+        datum: Datum = Datum("""
+        {
+            "id": "1",
+            "name": "awesome_name"
+        }
+        """, "json")
+        result: func.DocumentList = cdb.CosmosDBConverter.decode(data=datum, trigger_metadata=None)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['name'], 'awesome_name')
+
+    def test_cosmosdb_convert_json_name_is_null(self):
+        datum: Datum = Datum("""
+        {
+            "id": "1",
+            "name": null
+        }
+        """, "json")
+        result: func.DocumentList = cdb.CosmosDBConverter.decode(data=datum, trigger_metadata=None)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['name'], None)
+
+    def test_cosmosdb_convert_json_multiple_entries(self):
+        datum: Datum = Datum("""
+        [
+            {
+                "id": "1",
+                "name": "awesome_name"
+            },
+            {
+                "id": "2",
+                "name": "bossy_name"
+            }
+        ]
+        """, "json")
+        result: func.DocumentList = cdb.CosmosDBConverter.decode(data=datum, trigger_metadata=None)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]['name'], 'awesome_name')
+        self.assertEqual(result[1]['name'], 'bossy_name')
+
+    def test_cosmosdb_convert_json_multiple_nulls(self):
+        datum: Datum = Datum("[null]", "json")
+        result: func.DocumentList = cdb.CosmosDBConverter.decode(data=datum, trigger_metadata=None)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], None)

--- a/tests/test_cosmosdb.py
+++ b/tests/test_cosmosdb.py
@@ -4,9 +4,11 @@ import azure.functions as func
 import azure.functions.cosmosdb as cdb
 from azure.functions.meta import Datum
 
+
 class TestCosmosdb(unittest.TestCase):
     def test_cosmosdb_convert_none(self):
-        result: func.DocumentList = cdb.CosmosDBConverter.decode(data=None, trigger_metadata=None)
+        result: func.DocumentList = cdb.CosmosDBConverter.decode(
+            data=None, trigger_metadata=None)
         self.assertIsNone(result)
 
     def test_cosmosdb_convert_string(self):
@@ -16,7 +18,8 @@ class TestCosmosdb(unittest.TestCase):
             "name": "awesome_name"
         }
         """, "string")
-        result: func.DocumentList = cdb.CosmosDBConverter.decode(data=datum, trigger_metadata=None)
+        result: func.DocumentList = cdb.CosmosDBConverter.decode(
+            data=datum, trigger_metadata=None)
         self.assertIsNotNone(result)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]['name'], 'awesome_name')
@@ -28,7 +31,8 @@ class TestCosmosdb(unittest.TestCase):
             "name": "awesome_name"
         }
         """.encode(), "bytes")
-        result: func.DocumentList = cdb.CosmosDBConverter.decode(data=datum, trigger_metadata=None)
+        result: func.DocumentList = cdb.CosmosDBConverter.decode(
+            data=datum, trigger_metadata=None)
         self.assertIsNotNone(result)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]['name'], 'awesome_name')
@@ -40,7 +44,8 @@ class TestCosmosdb(unittest.TestCase):
             "name": "awesome_name"
         }
         """, "json")
-        result: func.DocumentList = cdb.CosmosDBConverter.decode(data=datum, trigger_metadata=None)
+        result: func.DocumentList = cdb.CosmosDBConverter.decode(
+            data=datum, trigger_metadata=None)
         self.assertIsNotNone(result)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]['name'], 'awesome_name')
@@ -52,7 +57,8 @@ class TestCosmosdb(unittest.TestCase):
             "name": null
         }
         """, "json")
-        result: func.DocumentList = cdb.CosmosDBConverter.decode(data=datum, trigger_metadata=None)
+        result: func.DocumentList = cdb.CosmosDBConverter.decode(
+            data=datum, trigger_metadata=None)
         self.assertIsNotNone(result)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]['name'], None)
@@ -70,7 +76,8 @@ class TestCosmosdb(unittest.TestCase):
             }
         ]
         """, "json")
-        result: func.DocumentList = cdb.CosmosDBConverter.decode(data=datum, trigger_metadata=None)
+        result: func.DocumentList = cdb.CosmosDBConverter.decode(
+            data=datum, trigger_metadata=None)
         self.assertIsNotNone(result)
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0]['name'], 'awesome_name')
@@ -78,7 +85,8 @@ class TestCosmosdb(unittest.TestCase):
 
     def test_cosmosdb_convert_json_multiple_nulls(self):
         datum: Datum = Datum("[null]", "json")
-        result: func.DocumentList = cdb.CosmosDBConverter.decode(data=datum, trigger_metadata=None)
+        result: func.DocumentList = cdb.CosmosDBConverter.decode(
+            data=datum, trigger_metadata=None)
         self.assertIsNotNone(result)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0], None)


### PR DESCRIPTION
Resolve https://github.com/Azure/azure-functions-python-worker/issues/548

Allow customer to fetch **null** value from DocumentList parameter when using CosmosDB trigger.