### PR TITLE
Allow azure functions to take in List[EventHubEvent]

### DIFF
--- a/azure/functions/eventhub.py
+++ b/azure/functions/eventhub.py
@@ -13,7 +13,8 @@ class EventHubConverter(meta.InConverter, meta.OutConverter,
     def check_input_type_annotation(cls, pytype: type) -> bool:
         return (
             issubclass(pytype, _eventhub.EventHubEvent)
-            or issubclass(pytype, typing.List)
+            or (issubclass(pytype, typing.List)
+                and issubclass(pytype.__args__[0], _eventhub.EventHubEvent))
         )
 
     @classmethod

--- a/azure/functions/eventhub.py
+++ b/azure/functions/eventhub.py
@@ -11,7 +11,10 @@ class EventHubConverter(meta.InConverter, meta.OutConverter,
 
     @classmethod
     def check_input_type_annotation(cls, pytype: type) -> bool:
-        return issubclass(pytype, _eventhub.EventHubEvent)
+        return (
+            issubclass(pytype, _eventhub.EventHubEvent)
+            or issubclass(pytype, typing.List)
+        )
 
     @classmethod
     def check_output_type_annotation(cls, pytype) -> bool:


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-functions-python-worker/issues/589

@jeffhollan mentioned that since we start supporting **cardinality** function settings, we should allow user to take in
- List[func.EventHubEvent] for **cardinality=many**
- func.EventHubEvent for **cardinality=one**