### PR TITLE
Allow Python 3.7 to use List[func.EventHubEvent]

### DIFF
--- a/azure/functions/eventhub.py
+++ b/azure/functions/eventhub.py
@@ -11,18 +11,18 @@ class EventHubConverter(meta.InConverter, meta.OutConverter,
 
     @classmethod
     def check_input_type_annotation(cls, pytype: type) -> bool:
+        valid_types = (_eventhub.EventHubEvent)
         return (
-            issubclass(pytype, _eventhub.EventHubEvent)
-            or (issubclass(pytype, typing.List)
-                and issubclass(pytype.__args__[0], _eventhub.EventHubEvent))
+            meta.is_iterable_type_annotation(pytype, valid_types) or
+            (isinstance(pytype, type) and issubclass(pytype, valid_types))
         )
 
     @classmethod
-    def check_output_type_annotation(cls, pytype) -> bool:
+    def check_output_type_annotation(cls, pytype: type) -> bool:
+        valid_types = (str, bytes)
         return (
-            issubclass(pytype, (str, bytes))
-            or (issubclass(pytype, typing.List)
-                and issubclass(pytype.__args__[0], str))
+            meta.is_iterable_type_annotation(pytype, str) or
+            (isinstance(pytype, type) and issubclass(pytype, valid_types))
         )
 
     @classmethod

--- a/tests/test_cosmosdb.py
+++ b/tests/test_cosmosdb.py
@@ -90,3 +90,15 @@ class TestCosmosdb(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0], None)
+
+    def test_cosmosdb_input_type(self):
+        check_input_type = cdb.CosmosDBConverter.check_input_type_annotation
+        self.assertTrue(check_input_type(func.DocumentList))
+        self.assertFalse(check_input_type(func.Document))
+        self.assertFalse(check_input_type(str))
+
+    def test_cosmosdb_output_type(self):
+        check_output_type = cdb.CosmosDBConverter.check_output_type_annotation
+        self.assertTrue(check_output_type(func.DocumentList))
+        self.assertTrue(check_output_type(func.Document))
+        self.assertFalse(check_output_type(str))

--- a/tests/test_eventhub.py
+++ b/tests/test_eventhub.py
@@ -1,0 +1,28 @@
+from typing import List
+import unittest
+
+import azure.functions as func
+import azure.functions.eventhub as azf_eh
+
+
+class TestEventHub(unittest.TestCase):
+    def test_eventhub_input_type(self):
+        check_input_type = (
+            azf_eh.EventHubConverter.check_input_type_annotation
+        )
+        self.assertTrue(check_input_type(func.EventHubEvent))
+        self.assertTrue(check_input_type(List[func.EventHubEvent]))
+        self.assertFalse(check_input_type(str))
+        self.assertFalse(check_input_type(bytes))
+        self.assertFalse(check_input_type(List[str]))
+
+    def test_eventhub_output_type(self):
+        check_output_type = (
+            azf_eh.EventHubTriggerConverter.check_output_type_annotation
+        )
+        self.assertTrue(check_output_type(bytes))
+        self.assertTrue(check_output_type(str))
+        self.assertTrue(check_output_type(List[str]))
+        self.assertFalse(check_output_type(func.EventHubEvent))
+        self.assertFalse(check_output_type(List[bytes]))
+        self.assertFalse(check_output_type(List[func.EventHubEvent]))

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,6 +1,7 @@
 import unittest
 
 import azure.functions as func
+import azure.functions.http as http
 
 
 class TestHTTP(unittest.TestCase):
@@ -55,3 +56,17 @@ class TestHTTP(unittest.TestCase):
         )
         self.assertEqual(req.form["foo"], u"Hello World")
         self.assertEqual(req.form["bar"], u"bar=baz")
+
+    def test_http_input_type(self):
+        check_input_type = (
+            http.HttpRequestConverter.check_input_type_annotation
+        )
+        self.assertTrue(check_input_type(func.HttpRequest))
+        self.assertFalse(check_input_type(str))
+
+    def test_http_output_type(self):
+        check_output_type = (
+            http.HttpResponseConverter.check_output_type_annotation
+        )
+        self.assertTrue(check_output_type(func.HttpResponse))
+        self.assertTrue(check_output_type(str))

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -2,6 +2,7 @@ import json
 import unittest
 
 import azure.functions as func
+import azure.functions.queue as azf_q
 
 
 class TestQueue(unittest.TestCase):
@@ -49,3 +50,19 @@ class TestQueue(unittest.TestCase):
 
         # then
         assert expected_body == test_queue_message.get_json()
+
+    def test_QueueMessage_input_type(self):
+        check_input_type = (
+            azf_q.QueueMessageInConverter.check_input_type_annotation
+        )
+        self.assertTrue(check_input_type(func.QueueMessage))
+        self.assertFalse(check_input_type(str))
+        self.assertFalse(check_input_type(bytes))
+
+    def test_QueueMessage_output_type(self):
+        check_output_type = (
+            azf_q.QueueMessageOutConverter.check_output_type_annotation
+        )
+        self.assertTrue(check_output_type(func.QueueMessage))
+        self.assertTrue(check_output_type(str))
+        self.assertTrue(check_output_type(bytes))


### PR DESCRIPTION
Since Python 3.7 change the implementation of generic type.
Now all the generic types (e.g. List, Set) are instantiated from **_GenericAlias** (previously in Python 3.6, they are instantiated from **type**). Thus, this affects all **issubclass** module usage because **List** and **Set** are not classes anymore.

To solve this issue, we get the generic type info from tp.\_\_origin\_\_ in Python 3.7.
