### PR TITLE
Fix local time parsing

### DIFF
--- a/azure/functions/_utils.py
+++ b/azure/functions/_utils.py
@@ -2,16 +2,16 @@ from typing import List, Tuple
 from datetime import datetime
 
 
-# Returns (is_matched, parsed_datetime, matched_format)
+# Returns (parsed_datetime, matched_format)
 def try_parse_datetime_with_formats(
     datetime_str: str,
     datetime_formats: List[str]
-) -> Tuple[bool, datetime, str]:
+) -> Tuple[bool, datetime, Exception]:
     for fmt in datetime_formats:
         try:
             dt = datetime.strptime(datetime_str, fmt)
-            return (True, dt, fmt)
-        except ValueError:
-            continue
+            return (dt, fmt, None)
+        except ValueError as ve:
+            last_exception = ve
 
-    return (False, None, None)
+    return (None, None, last_exception)

--- a/azure/functions/_utils.py
+++ b/azure/functions/_utils.py
@@ -1,0 +1,17 @@
+from typing import List, Tuple
+from datetime import datetime
+
+
+# Returns (is_matched, parsed_datetime, matched_format)
+def try_parse_datetime_with_formats(
+    datetime_str: str,
+    datetime_formats: List[str]
+) -> Tuple[bool, datetime, str]:
+    for fmt in datetime_formats:
+        try:
+            dt = datetime.strptime(datetime_str, fmt)
+            return (True, dt, fmt)
+        except ValueError:
+            continue
+
+    return (False, None, None)

--- a/azure/functions/meta.py
+++ b/azure/functions/meta.py
@@ -224,13 +224,11 @@ class _BaseConverter(metaclass=_ConverterMeta, binding=None):
             '%Y-%m-%dT%H:%M:%S.%fZ',
         ]
 
-        is_succeeded, dt, _ = try_parse_datetime_with_formats(
+        dt, _, excpt = try_parse_datetime_with_formats(
             datetime_str, utc_formats)
 
-        if not is_succeeded:
-            return None, ValueError(
-                f"Failed to parsed UTC datetime {datetime_str}")
-
+        if excpt is not None:
+            return None, excpt
         return dt, None
 
     @classmethod
@@ -245,13 +243,11 @@ class _BaseConverter(metaclass=_ConverterMeta, binding=None):
             '%Y-%m-%dT%H:%M:%S',
         ]
 
-        is_succeeded, dt, _ = try_parse_datetime_with_formats(
+        dt, _, excpt = try_parse_datetime_with_formats(
             datetime_str, local_formats)
 
-        if not is_succeeded:
-            return None, ValueError(
-                f"Failed to parsed local datetime {datetime_str}")
-
+        if excpt is not None:
+            return None, excpt
         return dt, None
 
     @classmethod

--- a/azure/functions/meta.py
+++ b/azure/functions/meta.py
@@ -6,6 +6,7 @@ import re
 import typing
 
 from ._thirdparty import typing_inspect
+from ._utils import try_parse_datetime_with_formats
 
 
 def is_iterable_type_annotation(annotation: object, pytype: object) -> bool:
@@ -223,15 +224,14 @@ class _BaseConverter(metaclass=_ConverterMeta, binding=None):
             '%Y-%m-%dT%H:%M:%S.%fZ',
         ]
 
-        dt = None
-        last_error = None
-        for utc_fmt in utc_formats:
-            try:
-                dt = datetime.datetime.strptime(datetime_str, utc_fmt)
-            except ValueError as e:
-                last_error = e
+        is_succeeded, dt, _ = try_parse_datetime_with_formats(
+            datetime_str, utc_formats)
 
-        return dt, last_error
+        if not is_succeeded:
+            return None, ValueError(
+                f"Failed to parsed UTC datetime {datetime_str}")
+
+        return dt, None
 
     @classmethod
     def _parse_datetime_local(
@@ -245,15 +245,14 @@ class _BaseConverter(metaclass=_ConverterMeta, binding=None):
             '%Y-%m-%dT%H:%M:%S',
         ]
 
-        dt = None
-        last_error = None
-        for local_fmt in local_formats:
-            try:
-                dt = datetime.datetime.strptime(datetime_str, local_fmt)
-            except ValueError as e:
-                last_error = e
+        is_succeeded, dt, _ = try_parse_datetime_with_formats(
+            datetime_str, local_formats)
 
-        return dt, last_error
+        if not is_succeeded:
+            return None, ValueError(
+                f"Failed to parsed local datetime {datetime_str}")
+
+        return dt, None
 
     @classmethod
     def _parse_timedelta(

--- a/azure/functions/meta.py
+++ b/azure/functions/meta.py
@@ -190,8 +190,7 @@ class _BaseConverter(metaclass=_ConverterMeta, binding=None):
             # a maxium of six, so strip it.
             # https://github.com/Azure/azure-functions-python-worker/issues/269
             datetime_str = too_fractional.group(1) + (
-                            too_fractional.group(3) or ''
-                           )
+                too_fractional.group(3) or '')
 
         # Try parse time
         utc_time, utc_time_error = cls._parse_datetime_utc(datetime_str)
@@ -210,7 +209,8 @@ class _BaseConverter(metaclass=_ConverterMeta, binding=None):
 
     @classmethod
     def _parse_datetime_utc(
-        cls, datetime_str: str) -> typing.Tuple[datetime.datetime, Exception]:
+        cls, datetime_str: str
+    ) -> typing.Tuple[datetime.datetime, Exception]:
 
         # UTC ISO 8601 assumed
         # 2018-08-07T23:17:57.461050Z
@@ -235,7 +235,8 @@ class _BaseConverter(metaclass=_ConverterMeta, binding=None):
 
     @classmethod
     def _parse_datetime_local(
-        cls, datetime_str: str) -> typing.Tuple[datetime.datetime, Exception]:
+        cls, datetime_str: str
+    ) -> typing.Tuple[datetime.datetime, Exception]:
 
         # Local time assumed
         # 2018-08-07T23:17:57.461050

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,19 +1,44 @@
 import unittest
+import datetime
 
 from azure.functions import meta
 
 
 class TestMeta(unittest.TestCase):
-    def test_datetime_parse(self):
+    def test_utc_datetime_no_fraction_parse(self):
+        parsed = self._parse_datetime('2018-12-12T03:16:34Z')
+        self.assertEqual(str(parsed), '2018-12-12 03:16:34+00:00')
+        self.assertEqual(parsed.tzinfo, datetime.timezone.utc)
+
+    def test_utc_datetime_parse(self):
         parsed = self._parse_datetime('2018-12-12T03:16:34.2191Z')
         self.assertEqual(str(parsed), '2018-12-12 03:16:34.219100+00:00')
 
-    def test_too_fractional_datetime_parse(self):
+    def test_utc_datetime_neg_tz_parse(self):
+        parsed = self._parse_datetime('2018-12-12T03:16:34.2191-00:00')
+        self.assertEqual(str(parsed), '2018-12-12 03:16:34.219100+00:00')
+
+    def test_too_fractional_utc_datetime_parse(self):
         parsed1 = self._parse_datetime('2018-12-12T03:16:34.2191989Z')
         self.assertEqual(str(parsed1), '2018-12-12 03:16:34.219198+00:00')
 
         parsed2 = self._parse_datetime('9999-12-31T23:59:59.9999999+00:00')
         self.assertEqual(str(parsed2), '9999-12-31 23:59:59.999999+00:00')
+
+    def test_local_datetime_no_fraction_parse(self):
+        parsed = self._parse_datetime('2018-12-12T03:16:34')
+        self.assertEqual(str(parsed), '2018-12-12 03:16:34')
+
+    def test_local_datetime_parse(self):
+        parsed = self._parse_datetime('2018-12-12T03:16:34.2191')
+        self.assertEqual(str(parsed), '2018-12-12 03:16:34.219100')
+
+    def test_too_fractional_local_datetime_parse(self):
+        parsed1 = self._parse_datetime('2018-08-07T23:17:57.4610506')
+        self.assertEqual(str(parsed1), '2018-08-07 23:17:57.461050')
+
+        parsed2 = self._parse_datetime('9999-12-31T23:59:59.9999999')
+        self.assertEqual(str(parsed2), '9999-12-31 23:59:59.999999')
 
     def _parse_datetime(self, datetime_str):
         return meta._BaseConverter._parse_datetime(datetime_str)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -40,5 +40,19 @@ class TestMeta(unittest.TestCase):
         parsed2 = self._parse_datetime('9999-12-31T23:59:59.9999999')
         self.assertEqual(str(parsed2), '9999-12-31 23:59:59.999999')
 
+    def test_parse_utc_datetime_failure(self):
+        malformed_utc = '2018-12-12X03:16:34.219289Z'
+        with self.assertRaises(ValueError) as context:
+            self._parse_datetime(malformed_utc)
+
+        self.assertIn(malformed_utc, str(context.exception))
+
+    def test_parse_local_datetime_failure(self):
+        malformed_local = '2018-12-12X03:16:34.219289'
+        with self.assertRaises(ValueError) as context:
+            self._parse_datetime(malformed_local)
+
+        self.assertIn(malformed_local, str(context.exception))
+
     def _parse_datetime(self, datetime_str):
         return meta._BaseConverter._parse_datetime(datetime_str)


### PR DESCRIPTION
### Related
Resolves https://github.com/Azure/azure-functions-python-worker/issues/591

### Issue
The Azure Media Service for EventGrid trigger metadata's event_time is a local time, which is not in ISO 8601 format. This PR fixes the local time parsing issue.