### PR TITLE
Allow null value when blob doesnt exist

### DIFF
--- a/azure/functions/blob.py
+++ b/azure/functions/blob.py
@@ -75,6 +75,9 @@ class BlobConverter(meta.InConverter,
 
     @classmethod
     def decode(cls, data: meta.Datum, *, trigger_metadata) -> typing.Any:
+        if data is None or data.type is None:
+            return None
+            
         data_type = data.type
 
         if data_type == 'string':


### PR DESCRIPTION
Returns None when a customer tries to access blob that doesn't exist