### PR TITLE
[PEP 561] add py.typed in azure.functions

### DIFF
--- a/azure/functions/py.typed
+++ b/azure/functions/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. The azure.functions package uses inline types.

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,9 @@ setup(
     ],
     license='MIT',
     packages=['azure.functions'],
+    package_data={
+        'azure.functions': ['py.typed']
+    },
     extras_require={
         'dev': [
             'flake8~=3.7.9',


### PR DESCRIPTION
resolves: https://github.com/Azure/azure-functions-python-library/issues/43

Adding the py.typed marker in azure.functions library

[PEP 561](https://www.python.org/dev/peps/pep-0561/#packaging-type-information)