### PR TITLE
Add orchestration trigger for durable functions

### DIFF
--- a/azure/functions/__init__.py
+++ b/azure/functions/__init__.py
@@ -7,6 +7,7 @@ from ._http import HttpResponse  # NoQA
 from ._http_wsgi import WsgiMiddleware # NoQA
 from ._queue import QueueMessage  # NoQA
 from ._servicebus import ServiceBusMessage  # NoQA
+from ._durable_functions import OrchestrationContext  # NoQA
 from .meta import get_binding_registry  # NoQA
 
 # Import binding implementations to register them
@@ -18,6 +19,7 @@ from . import http  # NoQA
 from . import queue  # NoQA
 from . import servicebus  # NoQA
 from . import timer  # NoQA
+from . import durable_functions  # NoQA
 
 
 __all__ = (
@@ -35,9 +37,12 @@ __all__ = (
     'EventHubEvent',
     'HttpRequest',
     'HttpResponse',
-    'WsgiMiddleware',
     'InputStream',
+    'OrchestrationContext',
     'QueueMessage',
     'ServiceBusMessage',
     'TimerRequest',
+
+    # Middlewares
+    'WsgiMiddleware',
 )

--- a/azure/functions/_abc.py
+++ b/azure/functions/_abc.py
@@ -300,3 +300,10 @@ class EventHubEvent(abc.ABC):
     @abc.abstractmethod
     def offset(self) -> typing.Optional[str]:
         pass
+
+
+class OrchestrationContext(abc.ABC):
+    @property
+    @abc.abstractmethod
+    def body(self) -> str:
+        pass

--- a/azure/functions/_durable_functions.py
+++ b/azure/functions/_durable_functions.py
@@ -1,3 +1,4 @@
+from typing import Union
 from . import _abc
 
 
@@ -5,15 +6,18 @@ class OrchestrationContext(_abc.OrchestrationContext):
     """A durable function orchestration context.
 
     :param str body:
-        The body of orchestration context.
+        The body of orchestration context json.
     """
 
     def __init__(self,
-                 body: str) -> None:
-        self.__body = body
+                 body: Union[str, bytes]) -> None:
+        if isinstance(body, str):
+            self.__body = body
+        if isinstance(body, bytes):
+            self.__body = body.decode('utf-8')
 
     @property
-    def body(self):
+    def body(self) -> str:
         return self.__body
 
     def __repr__(self):

--- a/azure/functions/_durable_functions.py
+++ b/azure/functions/_durable_functions.py
@@ -21,3 +21,6 @@ class OrchestrationContext(_abc.OrchestrationContext):
             f'<azure.OrchestrationContext '
             f'body={self.body}>'
         )
+
+    def __str__(self):
+        return self.__body

--- a/azure/functions/_durable_functions.py
+++ b/azure/functions/_durable_functions.py
@@ -1,0 +1,23 @@
+from . import _abc
+
+
+class OrchestrationContext(_abc.OrchestrationContext):
+    """A durable function orchestration context.
+
+    :param str body:
+        The body of orchestration context.
+    """
+
+    def __init__(self,
+                 body: str) -> None:
+        self.__body = body
+
+    @property
+    def body(self):
+        return self.__body
+
+    def __repr__(self):
+        return (
+            f'<azure.OrchestrationContext '
+            f'body={self.body}>'
+        )

--- a/azure/functions/durable_functions.py
+++ b/azure/functions/durable_functions.py
@@ -10,9 +10,7 @@ class OrchestrationTriggerConverter(meta.InConverter,
                                     trigger=True):
     @classmethod
     def check_input_type_annotation(cls, pytype):
-        return (issubclass(pytype, str)
-                or issubclass(pytype, bytes)
-                or issubclass(pytype, _durable_functions.OrchestrationContext))
+        return issubclass(pytype, str) or issubclass(pytype, bytes)
 
     @classmethod
     def decode(cls,

--- a/azure/functions/durable_functions.py
+++ b/azure/functions/durable_functions.py
@@ -1,0 +1,45 @@
+from typing import Any
+from azure.functions import _durable_functions
+
+from . import meta
+
+
+# Durable Function Orchestration Trigger
+class OrchestrationTriggerConverter(meta.InConverter,
+                                    binding='orchestrationTrigger',
+                                    trigger=True):
+    @classmethod
+    def check_input_type_annotation(cls, pytype):
+        return (issubclass(pytype, str)
+                or issubclass(pytype, bytes)
+                or issubclass(pytype, _durable_functions.OrchestrationContext))
+
+    @classmethod
+    def decode(cls,
+               data: meta.Datum, *,
+               trigger_metadata) -> _durable_functions.OrchestrationContext:
+        return _durable_functions.OrchestrationContext(data.value)
+
+    @classmethod
+    def has_implicit_output(cls) -> bool:
+        return True
+
+
+# Durable Function Activity Trigger
+class ActivityTriggerConverter(meta.InConverter,
+                               binding='activityTrigger',
+                               trigger=True):
+    @classmethod
+    def check_input_type_annotation(cls, pytype):
+        # Activity Trigger's arguments should accept any types
+        return True
+
+    @classmethod
+    def decode(cls,
+               data: meta.Datum, *,
+               trigger_metadata) -> Any:
+        return data.value
+
+    @classmethod
+    def has_implicit_output(cls) -> bool:
+        return True

--- a/azure/functions/durable_functions.py
+++ b/azure/functions/durable_functions.py
@@ -10,7 +10,7 @@ class OrchestrationTriggerConverter(meta.InConverter,
                                     trigger=True):
     @classmethod
     def check_input_type_annotation(cls, pytype):
-        return issubclass(pytype, str) or issubclass(pytype, bytes)
+        return issubclass(pytype, _durable_functions.OrchestrationContext)
 
     @classmethod
     def decode(cls,
@@ -36,7 +36,10 @@ class ActivityTriggerConverter(meta.InConverter,
     def decode(cls,
                data: meta.Datum, *,
                trigger_metadata) -> Any:
-        return data.value
+        if getattr(data, 'value', None) is not None:
+            return data.value
+
+        return data
 
     @classmethod
     def has_implicit_output(cls) -> bool:

--- a/azure/functions/meta.py
+++ b/azure/functions/meta.py
@@ -266,6 +266,10 @@ class InConverter(_BaseConverter, binding=None):
     def decode(cls, data: Datum, *, trigger_metadata) -> typing.Any:
         raise NotImplementedError
 
+    @abc.abstractclassmethod
+    def has_implicit_output(cls) -> bool:
+        return False
+
 
 class OutConverter(_BaseConverter, binding=None):
 

--- a/tests/test_durable_functions.py
+++ b/tests/test_durable_functions.py
@@ -59,13 +59,13 @@ class TestDurableFunctions(unittest.TestCase):
         self.assertEqual(content.get('name'), 'great function')
 
     def test_orchestration_trigger_check_good_annotation(self):
-        for dt in (str, bytes):
+        for dt in (OrchestrationContext,):
             self.assertTrue(
                 OrchestrationTriggerConverter.check_input_type_annotation(dt)
             )
 
     def test_orchestration_trigger_check_bad_annotation(self):
-        for dt in (int, OrchestrationContext):
+        for dt in (str, bytes, int):
             self.assertFalse(
                 OrchestrationTriggerConverter.check_input_type_annotation(dt)
             )

--- a/tests/test_durable_functions.py
+++ b/tests/test_durable_functions.py
@@ -1,0 +1,95 @@
+import unittest
+import json
+
+from azure.functions.durable_functions import (
+    OrchestrationTriggerConverter,
+    ActivityTriggerConverter
+)
+from azure.functions._durable_functions import OrchestrationContext
+from azure.functions.meta import Datum
+
+
+class TestDurableFunctions(unittest.TestCase):
+    def test_orchestration_context_string_body(self):
+        raw_string = '{ "name": "great function" }'
+        context = OrchestrationContext(raw_string)
+        self.assertIsNotNone(getattr(context, 'body', None))
+
+        content = json.loads(context.body)
+        self.assertEqual(content.get('name'), 'great function')
+
+    def test_orchestration_context_string_cast(self):
+        raw_string = '{ "name": "great function" }'
+        context = OrchestrationContext(raw_string)
+        self.assertEqual(str(context), raw_string)
+
+        content = json.loads(str(context))
+        self.assertEqual(content.get('name'), 'great function')
+
+    def test_orchestration_context_bytes_body(self):
+        raw_bytes = '{ "name": "great function" }'.encode('utf-8')
+        context = OrchestrationContext(raw_bytes)
+        self.assertIsNotNone(getattr(context, 'body', None))
+
+        content = json.loads(context.body)
+        self.assertEqual(content.get('name'), 'great function')
+
+    def test_orchestration_context_bytes_cast(self):
+        raw_bytes = '{ "name": "great function" }'.encode('utf-8')
+        context = OrchestrationContext(raw_bytes)
+        self.assertIsNotNone(getattr(context, 'body', None))
+
+        content = json.loads(context.body)
+        self.assertEqual(content.get('name'), 'great function')
+
+    def test_orchestration_trigger_converter(self):
+        datum = Datum(value='{ "name": "great function" }',
+                      type=str)
+        otc = OrchestrationTriggerConverter.decode(datum,
+                                                   trigger_metadata=None)
+        content = json.loads(otc.body)
+        self.assertEqual(content.get('name'), 'great function')
+
+    def test_orchestration_trigger_converter_type(self):
+        datum = Datum(value='{ "name": "great function" }'.encode('utf-8'),
+                      type=bytes)
+        otc = OrchestrationTriggerConverter.decode(datum,
+                                                   trigger_metadata=None)
+        content = json.loads(otc.body)
+        self.assertEqual(content.get('name'), 'great function')
+
+    def test_orchestration_trigger_check_good_annotation(self):
+        for dt in (str, bytes):
+            self.assertTrue(
+                OrchestrationTriggerConverter.check_input_type_annotation(dt)
+            )
+
+    def test_orchestration_trigger_check_bad_annotation(self):
+        for dt in (int, OrchestrationContext):
+            self.assertFalse(
+                OrchestrationTriggerConverter.check_input_type_annotation(dt)
+            )
+
+    def test_orchestration_trigger_has_implicit_return(self):
+        self.assertTrue(
+            OrchestrationTriggerConverter.has_implicit_output()
+        )
+
+    def test_activity_trigger_accepts_any_types(self):
+        datum_set = {
+            Datum('string', str),
+            Datum(123, int),
+            Datum(1234.56, float),
+            Datum('string'.encode('utf-8'), bytes),
+            Datum(Datum('{ "json": true }', str), Datum)
+        }
+
+        for datum in datum_set:
+            out = ActivityTriggerConverter.decode(datum, trigger_metadata=None)
+            self.assertEqual(out, datum.value)
+            self.assertEqual(type(out), datum.type)
+
+    def test_activity_trigger_has_implicit_return(self):
+        self.assertTrue(
+            ActivityTriggerConverter.has_implicit_output()
+        )

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -70,3 +70,11 @@ class TestHTTP(unittest.TestCase):
         )
         self.assertTrue(check_output_type(func.HttpResponse))
         self.assertTrue(check_output_type(str))
+
+    def test_http_request_should_not_have_implicit_output(self):
+        self.assertFalse(http.HttpRequestConverter.has_implicit_output())
+
+    def test_http_response_does_not_have_explicit_output(self):
+        self.assertIsNone(
+            getattr(http.HttpResponseConverter, 'has_implicit_output', None)
+        )


### PR DESCRIPTION
### Background
To support durable function running in Python Worker, we should create a rich binding for OrchestrationTrigger

### Features
1. Added an OrchestrationContext type for accepting orchestrate context
2. Allow user code to use `orchestration_context.body` to access the orchestration data
3. Set `has_implicit_output=True` for OrchestrationTrigger to enable context return even when `$return` is not defined in function.json

### Usage
```javascript
// function.json
{
  "scriptFile": "__init__.py",
  "bindings": [
    {
      "name": "orctx",  //context is a reserved keyword in azure functions Python, we use context to pass the function_name and invocation_id to our customers
      "type": "orchestrationTrigger",
      "direction": "in"
      // remove datatype here
    }
  ],
  "disabled": false
}
```

```python
# main.py
import azure.functions as func

def main(orctx: func.OrchestrationContext):
# or
# def main(orctx):
    orchestrate = df.Orchestrator.create(generator_function)
    result = orchestrate(orctx.body)  # need to add .body
    return result
```