### PR TITLE
Add activity trigger encode/decode logic for durable function

### DIFF
--- a/azure/functions/durable_functions.py
+++ b/azure/functions/durable_functions.py
@@ -72,7 +72,7 @@ class ActivityTriggerConverter(meta.InConverter,
                     f'valid json serializable ({data.value})')
         else:
             raise NotImplementedError(
-                f'unsupported event grid payload type: {data_type}')
+                f'unsupported activity trigger payload type: {data_type}')
 
         return result
 

--- a/azure/functions/durable_functions.py
+++ b/azure/functions/durable_functions.py
@@ -1,4 +1,6 @@
-from typing import Any
+import typing
+import json
+
 from azure.functions import _durable_functions
 
 from . import meta
@@ -6,11 +8,17 @@ from . import meta
 
 # Durable Function Orchestration Trigger
 class OrchestrationTriggerConverter(meta.InConverter,
+                                    meta.OutConverter,
                                     binding='orchestrationTrigger',
                                     trigger=True):
     @classmethod
     def check_input_type_annotation(cls, pytype):
         return issubclass(pytype, _durable_functions.OrchestrationContext)
+
+    @classmethod
+    def check_output_type_annotation(cls, pytype):
+        # Implicit output should accept any return type
+        return True
 
     @classmethod
     def decode(cls,
@@ -19,12 +27,19 @@ class OrchestrationTriggerConverter(meta.InConverter,
         return _durable_functions.OrchestrationContext(data.value)
 
     @classmethod
+    def encode(cls, obj: typing.Any, *,
+               expected_type: typing.Optional[type]) -> meta.Datum:
+        # Durable function context should be a json
+        return meta.Datum(type='json', value=obj)
+
+    @classmethod
     def has_implicit_output(cls) -> bool:
         return True
 
 
 # Durable Function Activity Trigger
 class ActivityTriggerConverter(meta.InConverter,
+                               meta.OutConverter,
                                binding='activityTrigger',
                                trigger=True):
     @classmethod
@@ -33,13 +48,44 @@ class ActivityTriggerConverter(meta.InConverter,
         return True
 
     @classmethod
+    def check_output_type_annotation(cls, pytype):
+        # Implicit output should accept any return type
+        return True
+
+    @classmethod
     def decode(cls,
                data: meta.Datum, *,
-               trigger_metadata) -> Any:
-        if getattr(data, 'value', None) is not None:
-            return data.value
+               trigger_metadata) -> typing.Any:
+        data_type = data.type
 
-        return data
+        # Durable functions extension always returns a string of json
+        # See durable functions library's call_activity_task docs
+        if data_type == 'string' or data_type == 'json':
+            try:
+                result = json.loads(data.value)
+            except json.JSONDecodeError:
+                # String failover if the content is not json serializable
+                result = data.value
+            except Exception:
+                raise ValueError(
+                    'activity trigger input must be a string or a '
+                    f'valid json serializable ({data.value})')
+        else:
+            raise NotImplementedError(
+                f'unsupported event grid payload type: {data_type}')
+
+        return result
+
+    @classmethod
+    def encode(cls, obj: typing.Any, *,
+               expected_type: typing.Optional[type]) -> meta.Datum:
+        try:
+            result = json.dumps(obj)
+        except TypeError:
+            raise ValueError(
+                f'activity trigger output must be json serializable ({obj})')
+
+        return meta.Datum(type='json', value=result)
 
     @classmethod
     def has_implicit_output(cls) -> bool:

--- a/azure/functions/durable_functions.py
+++ b/azure/functions/durable_functions.py
@@ -49,7 +49,7 @@ class ActivityTriggerConverter(meta.InConverter,
 
     @classmethod
     def check_output_type_annotation(cls, pytype):
-        # Implicit output should accept any return type
+        # The activity trigger should accept any JSON serializable types
         return True
 
     @classmethod

--- a/tests/test_durable_functions.py
+++ b/tests/test_durable_functions.py
@@ -96,12 +96,12 @@ class TestDurableFunctions(unittest.TestCase):
             },
             {
                 'input': Datum('[ "do", "re", "mi" ]', 'string'),
-                'expected_value': [ "do", "re", "mi" ],
+                'expected_value': ["do", "re", "mi"],
                 'expected_type': list
             },
             {
                 'input': Datum('{ "number": "42" }', 'string'),
-                'expected_value': { "number": "42" },
+                'expected_value': {"number": "42"},
                 'expected_type': dict
             }
         ]
@@ -130,11 +130,11 @@ class TestDurableFunctions(unittest.TestCase):
                 'expected_value': Datum('1234.56', 'json')
             },
             {
-                'output': [ "do", "re", "mi" ],
+                'output': ["do", "re", "mi"],
                 'expected_value': Datum('["do", "re", "mi"]', 'json')
             },
             {
-                'output': { "number": "42" },
+                'output': {"number": "42"},
                 'expected_value': Datum('{"number": "42"}', 'json')
             }
         ]


### PR DESCRIPTION
### Dependency
https://github.com/Azure/azure-functions-python-worker/pull/643

### Background
Previously, the Activity Trigger in Python Durable Functions only supports string as return value. Now, we should support JSON serializable Python primitive types.

✔string, int, float, bool, list of string/int/float/bool, dictionary of string/int/float/bool, None
❌set, frozenset, bytes, bytearray, custom type, custom dataclass 