### PR TITLE
Add func.__version__ dunder method (PEP 440)

### DIFF
--- a/azure/functions/__init__.py
+++ b/azure/functions/__init__.py
@@ -47,4 +47,4 @@ __all__ = (
     'WsgiMiddleware',
 )
 
-__version__ = '1.2.1'
+__version__ = '1.2.0'

--- a/azure/functions/__init__.py
+++ b/azure/functions/__init__.py
@@ -46,3 +46,5 @@ __all__ = (
     # Middlewares
     'WsgiMiddleware',
 )
+
+__version__ = '1.2.1'

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 from setuptools import setup
+from azure.functions import __version__
 
 
 setup(
     name='azure-functions',
-    version='1.2.0',
+    version=__version__,
     description='Azure Functions for Python',
     author='Microsoft Corporation',
     author_email='azpysdkhelp@microsoft.com',

--- a/tests/test_code_quality.py
+++ b/tests/test_code_quality.py
@@ -2,6 +2,8 @@ import pathlib
 import subprocess
 import sys
 import unittest
+import re
+import azure.functions as func
 
 
 ROOT_PATH = pathlib.Path(__file__).parent.parent
@@ -47,3 +49,11 @@ class TestCodeQuality(unittest.TestCase):
             output = ex.output.decode()
             raise AssertionError(
                 f'flake8 validation failed:\n{output}') from None
+
+    def test_library_version(self):
+        # PEP 440 Parsing version strings with regular expressions
+        is_valid = re.match(
+            r'^([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))'
+            r'*((a|b|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))'
+            r'?(\.dev(0|[1-9][0-9]*))?$', func.__version__) is not None
+        self.assertTrue(is_valid, '__version__ field must be canonical')


### PR DESCRIPTION
### Background
Customer should be able to query the version of the library they are currently using. According to PEP 440, __version__ is recommended to be part of the library.

### Resolves
resolves: https://github.com/Azure/azure-functions-python-library/issues/52