### PR TITLE
Adds Encode and Decode logic for "arbitrary" objects for Durable Python

### DIFF
--- a/azure/functions/__init__.py
+++ b/azure/functions/__init__.py
@@ -19,7 +19,6 @@ from . import queue  # NoQA
 from . import servicebus  # NoQA
 from . import timer  # NoQA
 from . import durable_functions  # NoQA
-from .durable_functions import __deserialize_custom_object, __serialize_custom_object
 
 
 __all__ = (
@@ -44,11 +43,7 @@ __all__ = (
     'TimerRequest',
 
     # Middlewares
-    'WsgiMiddleware',
-
-    # serialization
-    '__serialize_custom_object'
-    '__deserialize_custom_object'
+    'WsgiMiddleware'
 )
 
 __version__ = '1.2.0'

--- a/azure/functions/__init__.py
+++ b/azure/functions/__init__.py
@@ -9,7 +9,6 @@ from ._queue import QueueMessage  # NoQA
 from ._servicebus import ServiceBusMessage  # NoQA
 from ._durable_functions import OrchestrationContext  # NoQA
 from .meta import get_binding_registry  # NoQA
-
 # Import binding implementations to register them
 from . import blob  # NoQA
 from . import cosmosdb  # NoQA
@@ -20,6 +19,7 @@ from . import queue  # NoQA
 from . import servicebus  # NoQA
 from . import timer  # NoQA
 from . import durable_functions  # NoQA
+from durable_functions import __deserialize_custom_object, __serialize_custom_object
 
 
 __all__ = (
@@ -45,6 +45,10 @@ __all__ = (
 
     # Middlewares
     'WsgiMiddleware',
+
+    # serialization
+    '__serialize_custom_object'
+    '__deserialize_custom_object'
 )
 
 __version__ = '1.2.0'

--- a/azure/functions/__init__.py
+++ b/azure/functions/__init__.py
@@ -19,7 +19,7 @@ from . import queue  # NoQA
 from . import servicebus  # NoQA
 from . import timer  # NoQA
 from . import durable_functions  # NoQA
-from durable_functions import __deserialize_custom_object, __serialize_custom_object
+from .durable_functions import __deserialize_custom_object, __serialize_custom_object
 
 
 __all__ = (

--- a/azure/functions/_durable_functions.py
+++ b/azure/functions/_durable_functions.py
@@ -1,5 +1,84 @@
 from typing import Union
 from . import _abc
+from importlib import import_module
+
+
+# Utilities
+def _serialize_custom_object(obj):
+    """Serialize a user-defined object to JSON.
+
+    This function gets called when `json.dumps` cannot serialize
+    an object and returns a serializable dictionary containing enough
+    metadata to recontrust the original object.
+
+    Parameters
+    ----------
+    obj: Object
+        The object to serialize
+
+    Returns
+    -------
+    dict_obj: A serializable dictionary with enough metadata to reconstruct
+              `obj`
+
+    Exceptions
+    ----------
+    TypeError:
+        Raise if `obj` does not contain a `to_json` attribute
+    """
+    # 'safety' guard: raise error if object does not
+    # support serialization
+    if not hasattr(obj, "to_json"):
+        raise TypeError(f"class {type(obj)} does not expose a `to_json` "
+                        "function")
+    # Encode to json using the object's `to_json`
+    obj_type = type(obj)
+    dict_obj = {
+        "__class__" : obj.__class__.__name__,
+        "__module__": obj.__module__,
+        "__data__": obj_type.to_json(obj)
+    }
+    return dict_obj
+
+
+def _deserialize_custom_object(obj: dict) -> object:
+    """Deserialize a user-defined object from JSON.
+
+    Deserializes a dictionary encoding a custom object,
+    if it contains class metadata suggesting that it should be
+    decoded further.
+
+    Parameters:
+    ----------
+    obj: dict
+        Dictionary object that potentially encodes a custom class
+
+    Returns:
+    --------
+    object
+        Either the original `obj` dictionary or the custom object it encoded
+
+    Exceptions
+    ----------
+    TypeError
+        If the decoded object does not contain a `from_json` function
+    """
+    if ("__class__" in obj) and ("__module__" in obj) and ("__data__" in obj):
+        class_name = obj.pop("__class__")
+        module_name = obj.pop("__module__")
+        obj_data = obj.pop("__data__")
+
+        # Importing the clas
+        module = import_module(module_name)
+        class_ = getattr(module, class_name)
+
+        if not hasattr(class_, "from_json"):
+            raise TypeError(f"class {type(obj)} does not expose a `from_json` "
+                            "function")
+
+        # Initialize the object using its `from_json` deserializer
+        obj = class_.from_json(obj_data)
+    return obj
 
 
 class OrchestrationContext(_abc.OrchestrationContext):

--- a/azure/functions/_durable_functions.py
+++ b/azure/functions/_durable_functions.py
@@ -34,7 +34,7 @@ def _serialize_custom_object(obj):
     # Encode to json using the object's `to_json`
     obj_type = type(obj)
     dict_obj = {
-        "__class__" : obj.__class__.__name__,
+        "__class__": obj.__class__.__name__,
         "__module__": obj.__module__,
         "__data__": obj_type.to_json(obj)
     }

--- a/azure/functions/durable_functions.py
+++ b/azure/functions/durable_functions.py
@@ -6,75 +6,6 @@ from importlib import import_module
 
 from . import meta
 
-# Utilities
-def __serialize_custom_object(obj):
-    """This function gets called when `json.dumps` cannot serialize
-    an object and returns a serializable dictionary containing enough
-    metadata to recontrust the original object.
-
-    Parameters
-    ----------
-    obj: Object
-        The object to serialize
-
-    Returns
-    -------
-    dict_obj: A serializable dictionary with enough metadata to reconstruct `obj`
-
-    Exceptions
-    ----------
-    TypeError:
-        Raise if `obj` does not contain a `to_json` attribute
-    """
-    # 'safety' guard: raise error if object does not
-    # support serialization
-    if not hasattr(obj, "to_json"):
-        raise TypeError(f"class {type(obj)} does not expose a `to_json` function")
-    # Encode to json using the object's `to_json`
-    obj_type = type(obj)
-    dict_obj = {
-        "__class__" : obj.__class__.__name__,
-        "__module__": obj.__module__,
-        "__data__": obj_type.to_json(obj)
-    }
-    return dict_obj
-
-def __deserialize_custom_object(obj: dict) -> object:
-    """ Deserializes a dictionary encoding a custom object,
-    if it contains class metadata suggesting that it should be
-    decoded further.
-
-    Parameters:
-    ----------
-    obj: dict
-        Dictionary object that potentially encodes a custom class
-
-    Returns:
-    --------
-    object
-        Either the original `obj` dictionary or the custom object it encoded
-
-    Exceptions
-    ----------
-    TypeError
-        If the decoded object does not contain a `from_json` function
-    """
-    if ("__class__" in obj) and ("__module__" in obj) and ("__data__" in obj):
-        class_name = obj.pop("__class__")
-        module_name = obj.pop("__module__")
-        obj_data = obj.pop("__data__")
-        
-        # Importing the clas
-        module = import_module(module_name)
-        class_ = getattr(module,class_name)
-
-        if not hasattr(class_, "from_json"):
-            raise TypeError(f"class {type(obj)} does not expose a `from_json` function")
-        
-        # Initialize the object using its `from_json` deserializer
-        obj = class_.from_json(obj_data)
-    return obj
-
 
 # Durable Function Orchestration Trigger
 class OrchestrationTriggerConverter(meta.InConverter,
@@ -106,6 +37,7 @@ class OrchestrationTriggerConverter(meta.InConverter,
     def has_implicit_output(cls) -> bool:
         return True
 
+
 # Durable Function Activity Trigger
 class ActivityTriggerConverter(meta.InConverter,
                                meta.OutConverter,
@@ -131,7 +63,8 @@ class ActivityTriggerConverter(meta.InConverter,
         # See durable functions library's call_activity_task docs
         if data_type == 'string' or data_type == 'json':
             try:
-                result = json.loads(data.value, object_hook=__deserialize_custom_object)
+                callback = _durable_functions._deserialize_custom_object
+                result = json.loads(data.value, object_hook=callback)
             except json.JSONDecodeError:
                 # String failover if the content is not json serializable
                 result = data.value
@@ -149,7 +82,8 @@ class ActivityTriggerConverter(meta.InConverter,
     def encode(cls, obj: typing.Any, *,
                expected_type: typing.Optional[type]) -> meta.Datum:
         try:
-            result = json.dumps(obj, default=__serialize_custom_object)
+            callback = _durable_functions._serialize_custom_object
+            result = json.dumps(obj, default=callback)
         except TypeError:
             raise ValueError(
                 f'activity trigger output must be json serializable ({obj})')

--- a/azure/functions/durable_functions.py
+++ b/azure/functions/durable_functions.py
@@ -149,7 +149,7 @@ class ActivityTriggerConverter(meta.InConverter,
     def encode(cls, obj: typing.Any, *,
                expected_type: typing.Optional[type]) -> meta.Datum:
         try:
-        result = json.dumps(obj, default=__serialize_custom_object)
+            result = json.dumps(obj, default=__serialize_custom_object)
         except TypeError:
             raise ValueError(
                 f'activity trigger output must be json serializable ({obj})')

--- a/azure/functions/durable_functions.py
+++ b/azure/functions/durable_functions.py
@@ -2,8 +2,78 @@ import typing
 import json
 
 from azure.functions import _durable_functions
+from importlib import import_module
 
 from . import meta
+
+# Utilities
+def __serialize_custom_object(obj):
+    """This function gets called when `json.dumps` cannot serialize
+    an object and returns a serializable dictionary containing enough
+    metadata to recontrust the original object.
+
+    Parameters
+    ----------
+    obj: Object
+        The object to serialize
+
+    Returns
+    -------
+    dict_obj: A serializable dictionary with enough metadata to reconstruct `obj`
+
+    Exceptions
+    ----------
+    TypeError:
+        Raise if `obj` does not contain a `to_json` attribute
+    """
+    # 'safety' guard: raise error if object does not
+    # support serialization
+    if not hasattr(obj, "to_json"):
+        raise TypeError(f"class {type(obj)} does not expose a `to_json` function")
+    # Encode to json using the object's `to_json`
+    obj_type = type(obj)
+    dict_obj = {
+        "__class__" : obj.__class__.__name__,
+        "__module__": obj.__module__,
+        "__data__": obj_type.to_json(obj)
+    }
+    return dict_obj
+
+def __deserialize_custom_object(obj: dict) -> object:
+    """ Deserializes a dictionary encoding a custom object,
+    if it contains class metadata suggesting that it should be
+    decoded further.
+
+    Parameters:
+    ----------
+    obj: dict
+        Dictionary object that potentially encodes a custom class
+
+    Returns:
+    --------
+    object
+        Either the original `obj` dictionary or the custom object it encoded
+
+    Exceptions
+    ----------
+    TypeError
+        If the decoded object does not contain a `from_json` function
+    """
+    if ("__class__" in obj) and ("__module__" in obj) and ("__data__" in obj):
+        class_name = obj.pop("__class__")
+        module_name = obj.pop("__module__")
+        obj_data = obj.pop("__data__")
+        
+        # Importing the clas
+        module = import_module(module_name)
+        class_ = getattr(module,class_name)
+
+        if not hasattr(class_, "from_json"):
+            raise TypeError(f"class {type(obj)} does not expose a `from_json` function")
+        
+        # Initialize the object using its `from_json` deserializer
+        obj = class_.from_json(obj_data)
+    return obj
 
 
 # Durable Function Orchestration Trigger
@@ -36,7 +106,6 @@ class OrchestrationTriggerConverter(meta.InConverter,
     def has_implicit_output(cls) -> bool:
         return True
 
-
 # Durable Function Activity Trigger
 class ActivityTriggerConverter(meta.InConverter,
                                meta.OutConverter,
@@ -62,7 +131,7 @@ class ActivityTriggerConverter(meta.InConverter,
         # See durable functions library's call_activity_task docs
         if data_type == 'string' or data_type == 'json':
             try:
-                result = json.loads(data.value)
+                result = json.loads(data.value, object_hook=__deserialize_custom_object)
             except json.JSONDecodeError:
                 # String failover if the content is not json serializable
                 result = data.value
@@ -80,7 +149,7 @@ class ActivityTriggerConverter(meta.InConverter,
     def encode(cls, obj: typing.Any, *,
                expected_type: typing.Optional[type]) -> meta.Datum:
         try:
-            result = json.dumps(obj)
+        result = json.dumps(obj, default=__serialize_custom_object)
         except TypeError:
             raise ValueError(
                 f'activity trigger output must be json serializable ({obj})')

--- a/azure/functions/durable_functions.py
+++ b/azure/functions/durable_functions.py
@@ -2,8 +2,6 @@ import typing
 import json
 
 from azure.functions import _durable_functions
-from importlib import import_module
-
 from . import meta
 
 


### PR DESCRIPTION
This PR is a kind of "follow-up" to: https://github.com/Azure/azure-functions-python-library/pull/53

The Durable Functions Python group is looking to support custom objects as inputs and outputs for their Orchestrations and Activity Functions. To do this, we establish a kind of "contract" with the user that their custom classes will provide static `to_json` and `from_json` methods that we can use to serialize and deserialize their object instances. These functions get called as `json.dumps` and `json.loads` 'callbacks` at various points and throughout the library and the [durable-python ](https://github.com/Azure/azure-functions-durable-python) code itself.

So this PR does three things:
1) It defines the helper methods to serialize and de-serialize custom objects
2) Uses them in the ActivityTriggerConverters's `decode` and `encode` methods
3) Exposes them for further usage in Durable Python

I worry that the last point may be controversial, because we are exposing a framework-internal function and users doing `import azure.functions` would be able to see them. Now, the fact that they are prefixed by two underscores should signal that they are not for public usage. Another idea I had was to bundle the two serialization functions under a `__serialization__` module, and export that instead. Please let me know what you think, and than you 😸 