### PR TITLE
Expose metadata field in servicebus and eventhub

### DIFF
--- a/azure/functions/_eventhub.py
+++ b/azure/functions/_eventhub.py
@@ -1,7 +1,9 @@
 import datetime
+import json
 import typing
 
 from azure.functions import _abc as funcabc
+from azure.functions import meta
 
 
 class EventHubEvent(funcabc.EventHubEvent):
@@ -9,6 +11,7 @@ class EventHubEvent(funcabc.EventHubEvent):
 
     def __init__(self, *,
                  body: bytes,
+                 trigger_metadata: typing.Mapping[str, meta.Datum] = None,
                  enqueued_time: typing.Optional[datetime.datetime] = None,
                  partition_key: typing.Optional[str] = None,
                  sequence_number: typing.Optional[int] = None,
@@ -16,11 +19,15 @@ class EventHubEvent(funcabc.EventHubEvent):
                  iothub_metadata: typing.Optional[
                      typing.Mapping[str, str]] = None) -> None:
         self.__body = body
+        self.__trigger_metadata = trigger_metadata
         self.__enqueued_time = enqueued_time
         self.__partition_key = partition_key
         self.__sequence_number = sequence_number
         self.__offset = offset
         self.__iothub_metadata = iothub_metadata
+
+        # Cache for trigger metadata after json serialization
+        self._trigger_metadata_json: typing.Optional[str] = None
 
     def get_body(self) -> bytes:
         return self.__body
@@ -44,6 +51,26 @@ class EventHubEvent(funcabc.EventHubEvent):
     @property
     def offset(self) -> typing.Optional[str]:
         return self.__offset
+
+    @property
+    def metadata(self) -> str:
+        """Getting the raw JSON string from trigger_metadata.
+
+        Exposing the raw trigger_metadata to our customer. For cardinality=many
+        scenarios, each event points to the common metadata of all the events.
+
+        So when using metadata field when cardinality=many, it only needs to
+        take one of the events to get all the data (e.g. events[0].metadata).
+
+        Returns:
+        --------
+        str
+            Return the serialized JSON string of trigger metadata
+        """
+        if self._trigger_metadata_json is None:
+            self._trigger_metadata_json = json.dumps(self.__trigger_metadata,
+                                                     cls=meta.DatumJsonEncoder)
+        return self._trigger_metadata_json
 
     def __repr__(self) -> str:
         return (

--- a/azure/functions/_servicebus.py
+++ b/azure/functions/_servicebus.py
@@ -97,6 +97,6 @@ class ServiceBusMessage(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def metadata(self) -> str:
+    def metadata(self) -> typing.Optional[typing.Mapping[str, typing.Any]]:
         """The serialized JSON string from trigger metadata"""
         pass

--- a/azure/functions/_servicebus.py
+++ b/azure/functions/_servicebus.py
@@ -94,3 +94,9 @@ class ServiceBusMessage(abc.ABC):
     def user_properties(self) -> typing.Dict[str, object]:
         """User-defined message metadata."""
         pass
+
+    @property
+    @abc.abstractmethod
+    def metadata(self) -> str:
+        """The serialized JSON string from trigger metadata"""
+        pass

--- a/azure/functions/eventhub.py
+++ b/azure/functions/eventhub.py
@@ -142,7 +142,7 @@ class EventHubTriggerConverter(EventHubConverter,
 
     @classmethod
     def decode_multiple_events(
-            cls, data, trigger_metadata
+            cls, data, trigger_metadata: Mapping[str, meta.Datum]
     ) -> List[_eventhub.EventHubEvent]:
         if data.type == 'collection_bytes':
             parsed_data = data.value.bytes
@@ -156,7 +156,9 @@ class EventHubTriggerConverter(EventHubConverter,
 
         sys_props = trigger_metadata.get('SystemPropertiesArray')
 
-        parsed_sys_props = json.loads(sys_props.value)
+        parsed_sys_props: List[Any] = []
+        if sys_props is not None:
+            parsed_sys_props = json.loads(sys_props.value)
 
         if len(parsed_data) != len(parsed_sys_props):
             raise AssertionError('Number of bodies and metadata mismatched')

--- a/azure/functions/eventhub.py
+++ b/azure/functions/eventhub.py
@@ -99,7 +99,7 @@ class EventHubTriggerConverter(EventHubConverter,
                                binding='eventHubTrigger', trigger=True):
     @classmethod
     def decode(
-        cls, data: meta.Datum, *, trigger_metadata
+        cls, data: meta.Datum, *, trigger_metadata: Mapping[str, meta.Datum]
     ) -> Union[_eventhub.EventHubEvent, List[_eventhub.EventHubEvent]]:
         data_type = data.type
 
@@ -114,8 +114,9 @@ class EventHubTriggerConverter(EventHubConverter,
                 f'unsupported event data payload type: {data_type}')
 
     @classmethod
-    def decode_single_event(cls, data,
-                            trigger_metadata) -> _eventhub.EventHubEvent:
+    def decode_single_event(
+        cls, data, trigger_metadata: Mapping[str, meta.Datum]
+    ) -> _eventhub.EventHubEvent:
         if data.type == 'string':
             body = data.value.encode('utf-8')
 
@@ -127,6 +128,7 @@ class EventHubTriggerConverter(EventHubConverter,
 
         return _eventhub.EventHubEvent(
             body=body,
+            trigger_metadata=trigger_metadata,
             enqueued_time=cls._parse_datetime_metadata(
                 trigger_metadata, 'EnqueuedTime'),
             partition_key=cls._decode_trigger_metadata_field(
@@ -174,6 +176,7 @@ class EventHubTriggerConverter(EventHubConverter,
 
             event = _eventhub.EventHubEvent(
                 body=cls._marshall_event_body(parsed_data[i], data.type),
+                trigger_metadata=trigger_metadata,
                 enqueued_time=cls._parse_datetime(enqueued_time),
                 partition_key=cls._decode_typed_data(
                     partition_key, python_type=str),

--- a/azure/functions/servicebus.py
+++ b/azure/functions/servicebus.py
@@ -1,3 +1,4 @@
+import json
 import datetime
 import typing
 
@@ -12,10 +13,13 @@ class ServiceBusMessage(azf_sbus.ServiceBusMessage):
     def __init__(
             self, *,
             body: bytes,
+            trigger_metadata: typing.Mapping[str, typing.Any] = None,
             content_type: typing.Optional[str] = None,
             correlation_id: typing.Optional[str] = None,
             delivery_count: typing.Optional[int] = 0,
+            enqueued_time_utc: typing.Optional[datetime.datetime] = None,
             expiration_time: typing.Optional[datetime.datetime] = None,
+            expires_at_utc: typing.Optional[datetime.datetime] = None,
             label: typing.Optional[str] = None,
             message_id: str,
             partition_key: typing.Optional[str] = None,
@@ -28,10 +32,13 @@ class ServiceBusMessage(azf_sbus.ServiceBusMessage):
             user_properties: typing.Dict[str, object]) -> None:
 
         self.__body = body
+        self.__trigger_metadata = trigger_metadata
         self.__content_type = content_type
         self.__correlation_id = correlation_id
         self.__delivery_count = delivery_count
+        self.__enqueued_time_utc = enqueued_time_utc
         self.__expiration_time = expiration_time
+        self.__expires_at_utc = expires_at_utc
         self.__label = label
         self.__message_id = message_id
         self.__partition_key = partition_key
@@ -42,6 +49,9 @@ class ServiceBusMessage(azf_sbus.ServiceBusMessage):
         self.__time_to_live = time_to_live
         self.__to = to
         self.__user_properties = user_properties
+
+        # Cache for trigger metadata after json serialization
+        self._trigger_metadata_json: typing.Optional[str] = None
 
     def get_body(self) -> bytes:
         return self.__body
@@ -59,8 +69,16 @@ class ServiceBusMessage(azf_sbus.ServiceBusMessage):
         return self.__delivery_count
 
     @property
+    def enqueued_time_utc(self) -> typing.Optional[datetime.datetime]:
+        return self.__enqueued_time_utc
+
+    @property
     def expiration_time(self) -> typing.Optional[datetime.datetime]:
         return self.__expiration_time
+
+    @property
+    def expires_at_utc(self) -> typing.Optional[datetime.datetime]:
+        return self.__expires_at_utc
 
     @property
     def label(self) -> typing.Optional[str]:
@@ -102,6 +120,26 @@ class ServiceBusMessage(azf_sbus.ServiceBusMessage):
     def user_properties(self) -> typing.Dict[str, object]:
         return self.__user_properties
 
+    @property
+    def metadata(self) -> str:
+        """Getting the raw JSON string from trigger_metadata.
+
+        Exposing the raw trigger_metadata to our customer. For cardinality=many
+        scenarios, each event points to the common metadata of all the events.
+
+        So when using metadata field when cardinality=many, it only needs to
+        take one of the events to get all the data (e.g. events[0].metadata).
+
+        Returns:
+        --------
+        str
+            Return the serialized JSON string of trigger metadata
+        """
+        if self._trigger_metadata_json is None:
+            self._trigger_metadata_json = json.dumps(self.__trigger_metadata,
+                                                     cls=meta.DatumJsonEncoder)
+        return self._trigger_metadata_json
+
     def __repr__(self) -> str:
         return (
             f'<azure.functions.ServiceBusMessage '
@@ -119,7 +157,7 @@ class ServiceBusMessageInConverter(meta.InConverter,
 
     @classmethod
     def decode(cls, data: meta.Datum, *,
-               trigger_metadata) -> typing.Any:
+               trigger_metadata) -> ServiceBusMessage:
 
         if data is None:
             # ServiceBus message with no payload are possible.
@@ -145,14 +183,19 @@ class ServiceBusMessageInConverter(meta.InConverter,
 
         return ServiceBusMessage(
             body=body,
+            trigger_metadata=trigger_metadata,
             content_type=cls._decode_trigger_metadata_field(
                 trigger_metadata, 'ContentType', python_type=str),
             correlation_id=cls._decode_trigger_metadata_field(
                 trigger_metadata, 'CorrelationId', python_type=str),
             delivery_count=cls._decode_trigger_metadata_field(
                 trigger_metadata, 'DeliveryCount', python_type=int),
+            enqueued_time_utc=cls._parse_datetime_metadata(
+                trigger_metadata, 'EnqueuedTimeUtc'),
             expiration_time=cls._parse_datetime_metadata(
                 trigger_metadata, 'ExpirationTime'),
+            expires_at_utc=cls._parse_datetime_metadata(
+                trigger_metadata, 'ExpiresAtUtc'),
             label=cls._decode_trigger_metadata_field(
                 trigger_metadata, 'Label', python_type=str),
             message_id=cls._decode_trigger_metadata_field(

--- a/tests/test_eventhub.py
+++ b/tests/test_eventhub.py
@@ -177,6 +177,51 @@ class TestEventHub(unittest.TestCase):
             result[1].iothub_metadata['connection-device-id'], 'MyTestDevice2'
         )
 
+    def test_single_eventhub_trigger_metadata_field(self):
+        result = azf_eh.EventHubTriggerConverter.decode(
+            data=self._generate_single_iothub_datum(),
+            trigger_metadata=self._generate_single_trigger_metadatum()
+        )
+
+        # Checking the metadata field from trigger as json string
+        metadata_json = result.metadata
+        self.assertIsNotNone(metadata_json)
+
+        # System Properties should be propagated in metadata
+        metadata_dict = json.loads(metadata_json)
+        self.assertIsNotNone(metadata_dict.get('SystemProperties'))
+
+        # EnqueuedTime should be in iso8601 string format
+        self.assertEqual(metadata_dict['EnqueuedTime'],
+                         self.MOCKED_ENQUEUE_TIME.isoformat())
+        self.assertEqual(metadata_dict['SystemProperties'][
+            'iothub-connection-device-id'
+        ], 'MyTestDevice')
+
+    def test_multiple_eventhub_triggers_metadata_field(self):
+        result = azf_eh.EventHubTriggerConverter.decode(
+            data=self._generate_multiple_iothub_data(),
+            trigger_metadata=self._generate_multiple_trigger_metadata()
+        )
+
+        # Any of the event should contain the full metadata
+        event = result[0]
+        metadata_json = event.metadata
+        self.assertIsNotNone(metadata_json)
+
+        # System Properties should be propagated in metadata
+        metadata_dict = json.loads(metadata_json)
+
+        # Multiple metadata should be reflected in the list
+        self.assertIsNotNone(metadata_dict.get('SystemPropertiesArray'))
+
+        # EnqueuedTimeUtc should be in iso8601 string format
+        self.assertEqual(metadata_dict['SystemPropertiesArray'][0][
+            'EnqueuedTimeUtc'], self.MOCKED_ENQUEUE_TIME.isoformat())
+        self.assertEqual(metadata_dict['SystemPropertiesArray'][0][
+            'iothub-connection-device-id'
+        ], 'MyTestDevice1')
+
     def _generate_single_iothub_datum(self, datum_type='json'):
         datum = '{"device-status": "good"}'
         if datum_type == 'bytes':

--- a/tests/test_eventhub.py
+++ b/tests/test_eventhub.py
@@ -183,12 +183,11 @@ class TestEventHub(unittest.TestCase):
             trigger_metadata=self._generate_single_trigger_metadatum()
         )
 
-        # Checking the metadata field from trigger as json string
-        metadata_json = result.metadata
-        self.assertIsNotNone(metadata_json)
+        # Ensure the event enqueue_time property reflects the sys prop
+        self.assertEqual(result.enqueued_time, self.MOCKED_ENQUEUE_TIME)
 
         # System Properties should be propagated in metadata
-        metadata_dict = json.loads(metadata_json)
+        metadata_dict = result.metadata
         self.assertIsNotNone(metadata_dict.get('SystemProperties'))
 
         # EnqueuedTime should be in iso8601 string format
@@ -206,11 +205,11 @@ class TestEventHub(unittest.TestCase):
 
         # Any of the event should contain the full metadata
         event = result[0]
-        metadata_json = event.metadata
-        self.assertIsNotNone(metadata_json)
+        metadata_dict = event.metadata
+        self.assertIsNotNone(metadata_dict)
 
-        # System Properties should be propagated in metadata
-        metadata_dict = json.loads(metadata_json)
+        # Ensure the event enqueue_time property reflects the sys prop
+        self.assertEqual(event.enqueued_time, self.MOCKED_ENQUEUE_TIME)
 
         # Multiple metadata should be reflected in the list
         self.assertIsNotNone(metadata_dict.get('SystemPropertiesArray'))

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,3 +1,5 @@
+from typing import Mapping, List
+import json
 import unittest
 import datetime
 
@@ -53,6 +55,94 @@ class TestMeta(unittest.TestCase):
             self._parse_datetime(malformed_local)
 
         self.assertIn(malformed_local, str(context.exception))
+
+    def test_datum_json_encode_single_level(self):
+        encode = lambda d: json.dumps(d, cls=meta.DatumJsonEncoder)
+
+        datum: meta.Datum = None
+        self.assertEqual(encode(datum), "null")
+
+        datum = meta.Datum(value=1, type=None)
+        self.assertEqual(encode(datum), "null")
+
+        datum = meta.Datum(value=b"awesome bytes", type="bytes")
+        self.assertEqual(encode(datum), '"YXdlc29tZSBieXRlcw=="')
+
+        datum = meta.Datum(value="awesome string", type="string")
+        self.assertEqual(encode(datum), '"awesome string"')
+
+        datum = meta.Datum(value=42, type="int")
+        self.assertEqual(encode(datum), '42')
+
+        datum = meta.Datum(value=43.2103, type="double")
+        self.assertEqual(encode(datum), '43.2103')
+
+    def test_datum_json_encode_collections(self):
+        encode = lambda d: json.dumps(d, cls=meta.DatumJsonEncoder)
+
+        class DatumCollectionString:
+            def __init__(self, *args: List[str]):
+                self.string = args
+        datum = meta.Datum(value=DatumCollectionString("string 1", "string 2"),
+                           type="collection_string")
+        self.assertEqual(encode(datum), '["string 1", "string 2"]')
+
+        class DatumCollectionBytes:
+            def __init__(self, *args: List[bytes]):
+                self.bytes = args
+        datum = meta.Datum(value=DatumCollectionBytes(b"bytes 1", b"bytes 2"),
+                           type="collection_bytes")
+        self.assertEqual(encode(datum), '["Ynl0ZXMgMQ==", "Ynl0ZXMgMg=="]')
+
+        class DatumCollectionSint64:
+            def __init__(self, *args: List[int]):
+                self.sint64 = args
+        datum = meta.Datum(value=DatumCollectionSint64(1234567, 8901234),
+                           type="collection_sint64")
+        self.assertEqual(encode(datum), '[1234567, 8901234]')
+
+    def test_datum_json_encode_json(self):
+        encode = lambda d: json.dumps(d, cls=meta.DatumJsonEncoder)
+        # String
+        datum = meta.Datum(value='"string in json"',
+                           type="json")
+        self.assertEqual(encode(datum), '"string in json"')
+
+        # List
+        datum = meta.Datum(value='["a", "b", "c"]',
+                           type="json")
+        self.assertEqual(encode(datum), '["a", "b", "c"]')
+
+        # Object
+        datum = meta.Datum(value='{"name": "awesome", "value": "cool"}',
+                           type="json")
+        self.assertEqual(encode(datum), '{"name": "awesome", "value": "cool"}')
+
+        # Should ignore Newlines and Spaces
+        datum = meta.Datum(value='{ "name" : "awesome",\n "value":  "cool"\n}',
+                           type="json")
+        self.assertEqual(encode(datum), '{"name": "awesome", "value": "cool"}')
+
+    def test_datum_json_encode_hybrid_with_python_dict(self):
+        metadata_mock: Mapping[str, meta.Datum] = {}
+        metadata_mock["DeliveryCount"] = meta.Datum(1, type="int")
+        metadata_mock["LockToken"] = meta.Datum(
+            "42c893ad-b788-46f5-bfdd-f6e3257b7d75", type="string")
+        metadata_mock["sys"] = meta.Datum('''{
+            "MethodName": "ServiceBusSMany"
+        }''', type="json")
+
+        # Try to serialize it into json string
+        result = json.dumps(metadata_mock, cls=meta.DatumJsonEncoder)
+        self.assertIsNotNone(result)
+
+        # The deserialized_result should not have datum structure
+        deserialized_result = json.loads(result)
+        self.assertEqual(deserialized_result["DeliveryCount"], 1)
+        self.assertEqual(deserialized_result["LockToken"],
+                         "42c893ad-b788-46f5-bfdd-f6e3257b7d75")
+        self.assertEqual(deserialized_result["sys"]["MethodName"],
+                         "ServiceBusSMany")
 
     def _parse_datetime(self, datetime_str):
         return meta._BaseConverter._parse_datetime(datetime_str)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,5 +1,4 @@
 from typing import Mapping, List
-import json
 import unittest
 import datetime
 
@@ -56,93 +55,102 @@ class TestMeta(unittest.TestCase):
 
         self.assertIn(malformed_local, str(context.exception))
 
-    def test_datum_json_encode_single_level(self):
-        encode = lambda d: json.dumps(d, cls=meta.DatumJsonEncoder)
-
-        datum: meta.Datum = None
-        self.assertEqual(encode(datum), "null")
+    def test_datum_single_level_python_value(self):
+        datum: Mapping[str, meta.Datum] = meta.Datum(value=None, type="int")
+        self.assertEqual(datum.python_value, None)
+        self.assertEqual(datum.python_type, type(None))
 
         datum = meta.Datum(value=1, type=None)
-        self.assertEqual(encode(datum), "null")
+        self.assertEqual(datum.python_value, None)
+        self.assertEqual(datum.python_type, type(None))
 
         datum = meta.Datum(value=b"awesome bytes", type="bytes")
-        self.assertEqual(encode(datum), '"YXdlc29tZSBieXRlcw=="')
+        self.assertEqual(datum.python_value, b"awesome bytes")
+        self.assertEqual(datum.python_type, bytes)
 
         datum = meta.Datum(value="awesome string", type="string")
-        self.assertEqual(encode(datum), '"awesome string"')
+        self.assertEqual(datum.python_value, 'awesome string')
+        self.assertEqual(datum.python_type, str)
 
         datum = meta.Datum(value=42, type="int")
-        self.assertEqual(encode(datum), '42')
+        self.assertEqual(datum.python_value, 42)
+        self.assertEqual(datum.python_type, int)
 
         datum = meta.Datum(value=43.2103, type="double")
-        self.assertEqual(encode(datum), '43.2103')
+        self.assertEqual(datum.python_value, 43.2103)
+        self.assertEqual(datum.python_type, float)
 
-    def test_datum_json_encode_collections(self):
-        encode = lambda d: json.dumps(d, cls=meta.DatumJsonEncoder)
-
+    def test_datum_collections_python_value(self):
         class DatumCollectionString:
             def __init__(self, *args: List[str]):
                 self.string = args
         datum = meta.Datum(value=DatumCollectionString("string 1", "string 2"),
                            type="collection_string")
-        self.assertEqual(encode(datum), '["string 1", "string 2"]')
+        self.assertListEqual(datum.python_value, ["string 1", "string 2"])
+        self.assertEqual(datum.python_type, list)
 
         class DatumCollectionBytes:
             def __init__(self, *args: List[bytes]):
                 self.bytes = args
         datum = meta.Datum(value=DatumCollectionBytes(b"bytes 1", b"bytes 2"),
                            type="collection_bytes")
-        self.assertEqual(encode(datum), '["Ynl0ZXMgMQ==", "Ynl0ZXMgMg=="]')
+        self.assertListEqual(datum.python_value, [b"bytes 1", b"bytes 2"])
+        self.assertEqual(datum.python_type, list)
 
         class DatumCollectionSint64:
             def __init__(self, *args: List[int]):
                 self.sint64 = args
         datum = meta.Datum(value=DatumCollectionSint64(1234567, 8901234),
                            type="collection_sint64")
-        self.assertEqual(encode(datum), '[1234567, 8901234]')
+        self.assertListEqual(datum.python_value, [1234567, 8901234])
+        self.assertEqual(datum.python_type, list)
 
-    def test_datum_json_encode_json(self):
-        encode = lambda d: json.dumps(d, cls=meta.DatumJsonEncoder)
+    def test_datum_json_python_value(self):
+        # None
+        datum = meta.Datum(value='null',
+                           type="json")
+        self.assertEqual(datum.python_value, None)
+        self.assertEqual(datum.python_type, type(None))
+
+        # Int
+        datum = meta.Datum(value='123',
+                           type="json")
+        self.assertEqual(datum.python_value, 123)
+        self.assertEqual(datum.python_type, int)
+
+        # Float
+        datum = meta.Datum(value='456.789',
+                           type="json")
+        self.assertEqual(datum.python_value, 456.789)
+        self.assertEqual(datum.python_type, float)
+
         # String
         datum = meta.Datum(value='"string in json"',
                            type="json")
-        self.assertEqual(encode(datum), '"string in json"')
+        self.assertEqual(datum.python_value, "string in json")
+        self.assertEqual(datum.python_type, str)
 
         # List
         datum = meta.Datum(value='["a", "b", "c"]',
                            type="json")
-        self.assertEqual(encode(datum), '["a", "b", "c"]')
+        self.assertListEqual(datum.python_value, ["a", "b", "c"])
+        self.assertEqual(datum.python_type, list)
 
         # Object
         datum = meta.Datum(value='{"name": "awesome", "value": "cool"}',
                            type="json")
-        self.assertEqual(encode(datum), '{"name": "awesome", "value": "cool"}')
+        self.assertDictEqual(datum.python_value, {
+            "name": "awesome",
+            "value": "cool"})
+        self.assertEqual(datum.python_type, dict)
 
         # Should ignore Newlines and Spaces
         datum = meta.Datum(value='{ "name" : "awesome",\n "value":  "cool"\n}',
                            type="json")
-        self.assertEqual(encode(datum), '{"name": "awesome", "value": "cool"}')
-
-    def test_datum_json_encode_hybrid_with_python_dict(self):
-        metadata_mock: Mapping[str, meta.Datum] = {}
-        metadata_mock["DeliveryCount"] = meta.Datum(1, type="int")
-        metadata_mock["LockToken"] = meta.Datum(
-            "42c893ad-b788-46f5-bfdd-f6e3257b7d75", type="string")
-        metadata_mock["sys"] = meta.Datum('''{
-            "MethodName": "ServiceBusSMany"
-        }''', type="json")
-
-        # Try to serialize it into json string
-        result = json.dumps(metadata_mock, cls=meta.DatumJsonEncoder)
-        self.assertIsNotNone(result)
-
-        # The deserialized_result should not have datum structure
-        deserialized_result = json.loads(result)
-        self.assertEqual(deserialized_result["DeliveryCount"], 1)
-        self.assertEqual(deserialized_result["LockToken"],
-                         "42c893ad-b788-46f5-bfdd-f6e3257b7d75")
-        self.assertEqual(deserialized_result["sys"]["MethodName"],
-                         "ServiceBusSMany")
+        self.assertDictEqual(datum.python_value, {
+            "name": "awesome",
+            "value": "cool"})
+        self.assertEqual(datum.python_type, dict)
 
     def _parse_datetime(self, datetime_str):
         return meta._BaseConverter._parse_datetime(datetime_str)

--- a/tests/test_servicebus.py
+++ b/tests/test_servicebus.py
@@ -1,0 +1,132 @@
+from typing import Mapping
+import json
+import unittest
+from datetime import datetime, timezone
+
+import azure.functions as func
+import azure.functions.servicebus as azf_sb
+from azure.functions import meta
+
+
+class TestServiceBus(unittest.TestCase):
+    MOCKED_ENQUEUE_TIME = datetime.utcnow()
+
+    def test_servicebus_input_type(self):
+        check_input_type = (
+            azf_sb.ServiceBusMessageInConverter.check_input_type_annotation
+        )
+        # Should accept a service bus message as trigger input type
+        self.assertTrue(check_input_type(azf_sb.ServiceBusMessage))
+
+        # Should accept a message class derived from service bus
+        class ServiceBusMessageChild(azf_sb.ServiceBusMessage):
+            FOO = 'BAR'
+
+        self.assertTrue(check_input_type(ServiceBusMessageChild))
+
+        # Should be false if a message type does not match expectation
+        self.assertFalse(check_input_type(func.EventHubEvent))
+        self.assertFalse(check_input_type(str))
+        self.assertFalse(check_input_type(type(None)))
+
+    def test_servicebus_output_type(self):
+        check_output_type = (
+            azf_sb.ServiceBusMessageOutConverter.check_output_type_annotation
+        )
+        # Should accept bytes and string as trigger output type
+        self.assertTrue(check_output_type(bytes))
+        self.assertTrue(check_output_type(str))
+
+        # Should reject if attempt to send a service bus message out
+        self.assertFalse(check_output_type(azf_sb.ServiceBusMessage))
+
+        # Should be false if a message type does not match expectation
+        self.assertFalse(check_output_type(func.EventGridEvent))
+        self.assertFalse(check_output_type(type(None)))
+
+    def test_servicebus_data(self):
+        servicebus_msg = azf_sb.ServiceBusMessageInConverter.decode(
+            data=self._generate_servicebus_data(),
+            trigger_metadata=self._generate_servicebus_metadata())
+
+        servicebus_data = servicebus_msg.get_body().decode('utf-8')
+        self.assertEqual(servicebus_data, '{ "lucky_number": 23 }')
+
+    def test_servicebus_properties(self):
+        # SystemProperties in metadata should propagate to class properties
+        servicebus_msg = azf_sb.ServiceBusMessageInConverter.decode(
+            data=self._generate_servicebus_data(),
+            trigger_metadata=self._generate_servicebus_metadata())
+
+        self.assertEqual(servicebus_msg.content_type, 'application/json')
+        self.assertEqual(servicebus_msg.label, 'Microsoft.Azure.ServiceBus')
+        self.assertEqual(servicebus_msg.message_id,
+                         '87c66eaf88e84119b66a26278a7b4149')
+        self.assertEqual(servicebus_msg.enqueued_time_utc,
+                         self.MOCKED_ENQUEUE_TIME)
+        self.assertEqual(servicebus_msg.expires_at_utc,
+                         datetime(2020, 7, 2, 5, 39, 12, 170000,
+                                  tzinfo=timezone.utc))
+
+    def test_servicebus_metadata(self):
+        # Trigger metadata should contains all the essential information
+        # about this service bus message
+        servicebus_msg = azf_sb.ServiceBusMessageInConverter.decode(
+            data=self._generate_servicebus_data(),
+            trigger_metadata=self._generate_servicebus_metadata())
+
+        metadata_json = servicebus_msg.metadata
+        self.assertIsNotNone(metadata_json)
+
+        # Deserialize the json back to Python dictionary
+        # Datetime should be in iso8601 string instead of datetime object
+        metadata_dict = json.loads(metadata_json)
+        self.assertDictEqual(metadata_dict, {
+            'DeliveryCount': 1,
+            'LockToken': '87931fd2-39f4-415a-9fdc-adfdcbed3148',
+            'ExpiresAtUtc': '2020-07-02T05:39:12.17Z',
+            'EnqueuedTimeUtc': self.MOCKED_ENQUEUE_TIME.isoformat(),
+            'MessageId': '87c66eaf88e84119b66a26278a7b4149',
+            'ContentType': 'application/json',
+            'SequenceNumber': 3,
+            'Label': 'Microsoft.Azure.ServiceBus',
+            'sys': {
+                'MethodName': 'ServiceBusSMany',
+                'UtcNow': '2020-06-18T05:39:12.2860411Z',
+                'RandGuid': 'bb38deae-cc75-49f2-89f5-96ec6eb857db'
+            }
+        })
+
+    def _generate_servicebus_data(self):
+        return meta.Datum(value='{ "lucky_number": 23 }', type='json')
+
+    def _generate_servicebus_metadata(self):
+        mocked_metadata: Mapping[str, meta.Datum] = {}
+        mocked_metadata['DeliveryCount'] = meta.Datum(1, 'int')
+        mocked_metadata['LockToken'] = meta.Datum(
+            '87931fd2-39f4-415a-9fdc-adfdcbed3148', 'string'
+        )
+        mocked_metadata['ExpiresAtUtc'] = meta.Datum(
+            '2020-07-02T05:39:12.17Z', 'string'
+        )
+        mocked_metadata['EnqueuedTimeUtc'] = meta.Datum(
+            self.MOCKED_ENQUEUE_TIME.isoformat(), 'string'
+        )
+        mocked_metadata['MessageId'] = meta.Datum(
+            '87c66eaf88e84119b66a26278a7b4149', 'string'
+        )
+        mocked_metadata['ContentType'] = meta.Datum(
+            'application/json', 'string'
+        )
+        mocked_metadata['SequenceNumber'] = meta.Datum(3, 'int')
+        mocked_metadata['Label'] = meta.Datum(
+            'Microsoft.Azure.ServiceBus', 'string'
+        )
+        mocked_metadata['sys'] = meta.Datum(type='json', value='''
+            {
+                "MethodName": "ServiceBusSMany",
+                "UtcNow": "2020-06-18T05:39:12.2860411Z",
+                "RandGuid": "bb38deae-cc75-49f2-89f5-96ec6eb857db"
+            }
+            ''')
+        return mocked_metadata


### PR DESCRIPTION
### Issues
https://github.com/Azure/azure-functions-python-worker/issues/693

### Rational
Due to the constant change in extension schema, it is pretty hard for us to keep updating the rich type bindings (e.g. Node worker never do that, they always pass json to their customer). We should expose the **metadata** field to our customer, with a json inside.

### Implementation
Reconstruct meta.Datum item into Python object using **python_value** and **python_type** field. Cache it into a variable **_trigger_metadata_pyobj**. Expose **metadata** field to customer for Python dictionary access.

**Note**
GRPC collection_string and GRPC collection_sint64 will be serialized into json array.
GRPC Bytes and GRPC collection_bytes will be based64 encoded.

### EventHub & IoTHub Usage
For EventHub and IoTHub event, user now have access to **metadata** field, which is a Python dictionary. The metadata is bound to an event object. That says, when cardinality=one, use `event.metadata` and when cardinality=many, use `event[0].metadata`. Example as follow:
```
{
  "PartitionContext": {
    "CancellationToken": {
      "IsCancellationRequested": false,
      "CanBeCanceled": true,
      "WaitHandle": {
        "Handle": {
          "value": 3592
        },
        "SafeWaitHandle": {
          "IsInvalid": false,
          "IsClosed": false
        }
      }
    },
    "ConsumerGroupName": "$Default",
    "EventHubPath": "a-eh",
    "PartitionId": "0",
    "Owner": "865713bf-b827-465b-ad2c-66209c585869",
    "RuntimeInformation": {
      "PartitionId": "0",
      "LastSequenceNumber": 0,
      "LastEnqueuedTimeUtc": "0001-01-01T00:00:00",
      "LastEnqueuedOffset": null,
      "RetrievalTime": "0001-01-01T00:00:00"
    }
  },
  "PartitionKeyArray": [],
  "OffsetArray": [
    "25769827512"
  ],
  "SequenceNumberArray": [
    96
  ],
  "EnqueuedTimeUtcArray": [
    "2020-06-18T04:40:04.171Z"
  ],
  "PropertiesArray": [
    {}
  ],
  "SystemPropertiesArray": [
    {
      "x-opt-scheduled-enqueue-time": "2020-06-18T04:40:03.643Z",
      "x-opt-sequence-number": 96,
      "x-opt-offset": "25769827512",
      "x-opt-enqueued-time": "2020-06-18T04:40:04.171Z",
      "SequenceNumber": 96,
      "Offset": "25769827512",
      "PartitionKey": null,
      "EnqueuedTimeUtc": "2020-06-18T04:40:04.171Z"
    }
  ],
  "sys": {
    "MethodName": "EventHubAMany",
    "UtcNow": "2020-06-18T04:40:04.3098934Z",
    "RandGuid": "501abf96-5db4-417f-a13e-8bb550324939"
  }
}
```

### ServiceBus Usage
Pretty similar, use `message.metadata` to acquire the metadata. Also added two additional properties **enqueued_time_utc** and **expires_at_utc**. Example below:
```
{
  "DeliveryCount": 1,
  "LockToken": "87931fd2-39f4-415a-9fdc-adfdcbed3148",
  "ExpiresAtUtc": "2020-07-02T05:39:12.17Z",
  "EnqueuedTimeUtc": "2020-06-18T05:39:12.17Z",
  "MessageId": "87c66eaf88e84119b66a26278a7b4149",
  "ContentType": "application/json",
  "SequenceNumber": 3,
  "Label": "Microsoft.Azure.ServiceBus",
  "UserProperties": {},
  "MessageReceiver": {
    "RegisteredPlugins": [],
    "ReceiveMode": 0,
    "PrefetchCount": 0,
    "LastPeekedSequenceNumber": 0,
    "Path": "hazeng-sb-s",
    "OperationTimeout": "00:01:00",
    "ServiceBusConnection": {
      "Endpoint": "sb://hazeng.servicebus.windows.net",
      "OperationTimeout": "00:01:00",
      "RetryPolicy": {
        "MinimalBackoff": "00:00:00",
        "MaximumBackoff": "00:00:30",
        "DeltaBackoff": "00:00:03",
        "MaxRetryCount": 5,
        "IsServerBusy": false,
        "ServerBusyExceptionMessage": null
      },
      "TransportType": 0,
      "TokenProvider": {},
      "IsClosedOrClosing": false
    },
    "IsClosedOrClosing": false,
    "OwnsConnection": true,
    "ClientId": "MessageReceiver1hazeng-sb-s",
    "RetryPolicy": {
      "MinimalBackoff": "00:00:00",
      "MaximumBackoff": "00:00:30",
      "DeltaBackoff": "00:00:03",
      "MaxRetryCount": 5,
      "IsServerBusy": false,
      "ServerBusyExceptionMessage": null
    }
  },
  "sys": {
    "MethodName": "ServiceBusSMany",
    "UtcNow": "2020-06-18T05:39:12.2860411Z",
    "RandGuid": "bb38deae-cc75-49f2-89f5-96ec6eb857db"
  }
}
```

### Todo
Update documentation to promote metadata usage.