### PR TITLE
Fix EnqueueTimeUtc in EventHub and expose ServiceBus new properties 

### DIFF
--- a/azure/functions/_servicebus.py
+++ b/azure/functions/_servicebus.py
@@ -33,6 +33,18 @@ class ServiceBusMessage(abc.ABC):
 
     @property
     @abc.abstractmethod
+    def enqueued_time_utc(self) -> typing.Optional[datetime.datetime]:
+        """The date and time in UTC at which the message is enqueued"""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def expires_at_utc(self) -> typing.Optional[datetime.datetime]:
+        """The date and time in UTC at which the message is set to expire."""
+        pass
+
+    @property
+    @abc.abstractmethod
     def expiration_time(self) -> typing.Optional[datetime.datetime]:
         """The date and time in UTC at which the message is set to expire."""
         pass

--- a/azure/functions/eventhub.py
+++ b/azure/functions/eventhub.py
@@ -125,7 +125,7 @@ class EventHubTriggerConverter(EventHubConverter,
             body=body,
             trigger_metadata=trigger_metadata,
             enqueued_time=cls._parse_datetime_metadata(
-                trigger_metadata, 'EnqueuedTime'),
+                trigger_metadata, 'EnqueuedTimeUtc'),
             partition_key=cls._decode_trigger_metadata_field(
                 trigger_metadata, 'PartitionKey', python_type=str),
             sequence_number=cls._decode_trigger_metadata_field(

--- a/tests/test_eventhub.py
+++ b/tests/test_eventhub.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from typing import List
+from typing import List, Mapping
 import unittest
 import json
 from unittest.mock import patch
@@ -223,6 +223,78 @@ class TestEventHub(unittest.TestCase):
         self.assertEqual(metadata_dict['SystemPropertiesArray'][0][
             'iothub-connection-device-id'
         ], 'MyTestDevice1')
+
+    def test_eventhub_properties(self):
+        """Test if properties from public interface _eventhub.py returns
+        the correct values from metadata"""
+
+        result = azf_eh.EventHubTriggerConverter.decode(
+            data=meta.Datum(b'body_bytes', 'bytes'),
+            trigger_metadata=self._generate_full_metadata()
+        )
+
+        self.assertEqual(result.get_body(), b'body_bytes')
+        self.assertIsNone(result.partition_key)
+        self.assertDictEqual(result.iothub_metadata,
+                             {'connection-device-id': 'awesome-device-id'})
+        self.assertEqual(result.sequence_number, 47)
+        self.assertEqual(result.enqueued_time.isoformat(),
+                         '2020-07-14T01:27:55.627000+00:00')
+        self.assertEqual(result.offset, '3696')
+
+    def _generate_full_metadata(self):
+        mocked_metadata: Mapping[str, meta.Datum] = {}
+        mocked_metadata['Offset'] = meta.Datum(type='string', value='3696')
+        mocked_metadata['EnqueuedTimeUtc'] = meta.Datum(
+            type='string', value='2020-07-14T01:27:55.627Z')
+        mocked_metadata['SequenceNumber'] = meta.Datum(type='int', value=47)
+        mocked_metadata['Properties'] = meta.Datum(type='json', value='{}')
+        mocked_metadata['sys'] = meta.Datum(type='json', value='''
+        {
+            "MethodName":"metadata_trigger",
+            "UtcNow":"2020-07-14T01:27:55.8940305Z",
+            "RandGuid":"db413fd6-8411-4e51-844c-c9b5345e537d"
+        }''')
+        mocked_metadata['SystemProperties'] = meta.Datum(type='json', value='''
+        {
+            "x-opt-sequence-number":47,
+            "x-opt-offset":"3696",
+            "x-opt-enqueued-time":"2020-07-14T01:27:55.627Z",
+            "SequenceNumber":47,
+            "Offset":"3696",
+            "PartitionKey":null,
+            "EnqueuedTimeUtc":"2020-07-14T01:27:55.627Z",
+            "iothub-connection-device-id":"awesome-device-id"
+        }''')
+        mocked_metadata['PartitionContext'] = meta.Datum(type='json', value='''
+        {
+            "CancellationToken":{
+            "IsCancellationRequested":false,
+            "CanBeCanceled":true,
+            "WaitHandle":{
+                "Handle":{
+                    "value":2472
+                },
+                "SafeWaitHandle":{
+                    "IsInvalid":false,
+                    "IsClosed":false
+                }
+            }
+            },
+            "ConsumerGroupName":"$Default",
+            "EventHubPath":"python-worker-ci-eventhub-one-metadata",
+            "PartitionId":"0",
+            "Owner":"88cec2e2-94c9-4e08-acb6-4f2b97cd888e",
+            "RuntimeInformation":{
+            "PartitionId":"0",
+            "LastSequenceNumber":0,
+            "LastEnqueuedTimeUtc":"0001-01-01T00:00:00",
+            "LastEnqueuedOffset":null,
+            "RetrievalTime":"0001-01-01T00:00:00"
+            }
+        }''')
+
+        return mocked_metadata
 
     def _generate_single_iothub_datum(self, datum_type='json'):
         datum = '{"device-status": "good"}'

--- a/tests/test_eventhub.py
+++ b/tests/test_eventhub.py
@@ -194,7 +194,7 @@ class TestEventHub(unittest.TestCase):
         self.assertIsNotNone(metadata_dict.get('SystemProperties'))
 
         # EnqueuedTime should be in iso8601 string format
-        self.assertEqual(metadata_dict['EnqueuedTime'],
+        self.assertEqual(metadata_dict['EnqueuedTimeUtc'],
                          self.MOCKED_ENQUEUE_TIME.isoformat())
         self.assertEqual(metadata_dict['SystemProperties'][
             'iothub-connection-device-id'
@@ -248,7 +248,7 @@ class TestEventHub(unittest.TestCase):
 
     def _generate_single_trigger_metadatum(self):
         return {
-            'EnqueuedTime': meta.Datum(
+            'EnqueuedTimeUtc': meta.Datum(
                 f'"{self.MOCKED_ENQUEUE_TIME.isoformat()}"', 'json'
             ),
             'SystemProperties': meta.Datum(

--- a/tests/test_servicebus.py
+++ b/tests/test_servicebus.py
@@ -91,23 +91,21 @@ class TestServiceBus(unittest.TestCase):
 
         # Datetime should be in iso8601 string instead of datetime object
         metadata_dict = servicebus_msg.metadata
-        self.assertEqual(metadata_dict['DeliveryCount'], 1)
-        self.assertEqual(metadata_dict['LockToken'],
-                         '87931fd2-39f4-415a-9fdc-adfdcbed3148')
-        self.assertEqual(metadata_dict['ExpiresAtUtc'],
-                         '2020-07-02T05:39:12.17Z')
-        self.assertEqual(metadata_dict['EnqueuedTimeUtc'],
-                         self.MOCKED_ENQUEUE_TIME.isoformat())
-        self.assertEqual(metadata_dict['MessageId'],
-                         '87c66eaf88e84119b66a26278a7b4149')
-        self.assertEqual(metadata_dict['ContentType'], 'application/json')
-        self.assertEqual(metadata_dict['SequenceNumber'], 3)
-        self.assertEqual(metadata_dict['Label'], 'Microsoft.Azure.ServiceBus')
-        self.assertDictEqual(metadata_dict['sys'], {
-            'MethodName': 'ServiceBusSMany',
-            'UtcNow': '2020-06-18T05:39:12.2860411Z',
-            'RandGuid': 'bb38deae-cc75-49f2-89f5-96ec6eb857db'
-        })
+        self.assertGreaterEqual(metadata_dict.items(), {
+            'DeliveryCount': 1,
+            'LockToken': '87931fd2-39f4-415a-9fdc-adfdcbed3148',
+            'ExpiresAtUtc': '2020-07-02T05:39:12.17Z',
+            'EnqueuedTimeUtc': self.MOCKED_ENQUEUE_TIME.isoformat(),
+            'MessageId': '87c66eaf88e84119b66a26278a7b4149',
+            'ContentType': 'application/json',
+            'SequenceNumber': 3,
+            'Label': 'Microsoft.Azure.ServiceBus',
+            'sys': {
+                'MethodName': 'ServiceBusSMany',
+                'UtcNow': '2020-06-18T05:39:12.2860411Z',
+                'RandGuid': 'bb38deae-cc75-49f2-89f5-96ec6eb857db'
+            }
+        }.items())
 
     def test_servicebus_should_not_override_metadata(self):
         # SystemProperties in metadata should propagate to class properties


### PR DESCRIPTION
### Descriptions
1. The single EventHub enqueue_time field now extract data from `trigger_metadata['EnqueuedTimeUtc']` instead of `trigger_metadata['EnqueuedTime']`.
2. The newly introduced ServiceBus properties **expires_at_utc** and **enqueued_time_utc** need to be exposed at _servicebus.py public interface.
3. Add more robust tests in EventHub event properties and ServiceBus message properties.