### PR TITLE
Input binding returns null when blob does not exist

### DIFF
--- a/azure/functions/blob.py
+++ b/azure/functions/blob.py
@@ -78,6 +78,9 @@ class BlobConverter(meta.InConverter,
 
     @classmethod
     def decode(cls, data: meta.Datum, *, trigger_metadata) -> Any:
+        if data is None or data.type is None:
+            return None
+
         data_type = data.type
 
         if data_type == 'string':

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -1,0 +1,104 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from typing import Dict, Any
+import unittest
+
+import azure.functions as func
+import azure.functions.blob as afb
+from azure.functions.meta import Datum
+from azure.functions.blob import InputStream
+
+
+class TestBlob(unittest.TestCase):
+    def test_blob_input_type(self):
+        check_input_type = afb.BlobConverter.check_input_type_annotation
+        self.assertTrue(check_input_type(str))
+        self.assertTrue(check_input_type(bytes))
+        self.assertTrue(check_input_type(InputStream))
+        self.assertFalse(check_input_type(bytearray))
+
+    def test_blob_input_none(self):
+        result: func.DocumentList = afb.BlobConverter.decode(
+            data=None, trigger_metadata=None)
+        self.assertIsNone(result)
+
+    def test_blob_input_string_no_metadata(self):
+        datum: Datum = Datum(value='string_content', type='string')
+        result: InputStream = afb.BlobConverter.decode(
+            data=datum, trigger_metadata=None)
+        self.assertIsNotNone(result)
+
+        # Verify result metadata
+        self.assertIsInstance(result, InputStream)
+        self.assertIsNone(result.name)
+        self.assertIsNone(result.length)
+        self.assertIsNone(result.uri)
+        self.assertTrue(result.readable())
+        self.assertFalse(result.seekable())
+        self.assertFalse(result.writable())
+
+        # Verify result content
+        content: bytes = result.read()
+        self.assertEqual(content, b'string_content')
+
+    def test_blob_input_bytes_no_metadata(self):
+        datum: Datum = Datum(value=b'bytes_content', type='bytes')
+        result: InputStream = afb.BlobConverter.decode(
+            data=datum, trigger_metadata=None)
+        self.assertIsNotNone(result)
+
+        # Verify result metadata
+        self.assertIsInstance(result, InputStream)
+        self.assertIsNone(result.name)
+        self.assertIsNone(result.length)
+        self.assertIsNone(result.uri)
+        self.assertTrue(result.readable())
+        self.assertFalse(result.seekable())
+        self.assertFalse(result.writable())
+
+        # Verify result content
+        content: bytes = result.read()
+        self.assertEqual(content, b'bytes_content')
+
+    def test_blob_input_with_metadata(self):
+        datum: Datum = Datum(value=b'blob_content', type='bytes')
+        metadata: Dict[str, Any] = {
+            'Properties': Datum('{"Length": "12"}', 'json'),
+            'BlobTrigger': Datum('blob_trigger_name', 'string'),
+            'Uri': Datum('https://test.io/blob_trigger', 'string')
+        }
+        result: InputStream = afb.BlobConverter.decode(
+            data=datum, trigger_metadata=metadata)
+
+        # Verify result metadata
+        self.assertIsInstance(result, InputStream)
+        self.assertEqual(result.name, 'blob_trigger_name')
+        self.assertEqual(result.length, len(b'blob_content'))
+        self.assertEqual(result.uri, 'https://test.io/blob_trigger')
+
+    def test_blob_incomplete_read(self):
+        datum: Datum = Datum(value=b'blob_content', type='bytes')
+        result: InputStream = afb.BlobConverter.decode(
+            data=datum, trigger_metadata=None)
+
+        self.assertEqual(result.read(size=3), b'blo')
+
+    def test_blob_output_type(self):
+        check_output_type = afb.BlobConverter.check_output_type_annotation
+        self.assertTrue(check_output_type(str))
+        self.assertTrue(check_output_type(bytes))
+        self.assertTrue(check_output_type(bytearray))
+        self.assertTrue(check_output_type(InputStream))
+
+    def test_blob_output_custom_type(self):
+        class CustomOutput:
+            def read(self) -> bytes:
+                return b'custom_output_content'
+
+        check_output_type = afb.BlobConverter.check_output_type_annotation
+        self.assertTrue(check_output_type(CustomOutput))
+
+    def test_blob_output_custom_output_content(self):
+        class CustomOutput:
+            def read(self) -> bytes:


### PR DESCRIPTION
### Background
Resolves https://github.com/Azure/azure-functions-python-library/issues/39
Resolves https://github.com/Azure/azure-functions-python-worker/issues/670 
Original PR: https://github.com/Azure/azure-functions-python-library/pull/40 

When a blob does not exist, the blob input binding will raise an exception. Asked by the issues mentioned above, we should simply return a None object in the input binding since it is not a customer error.

### Fixes
1. The Blob input binding will now return None if the blob does not exist
2. Add unit testing for blob trigger