### PR TITLE
remove unneeded noqa comments

### DIFF
--- a/azure/functions/__init__.py
+++ b/azure/functions/__init__.py
@@ -1,18 +1,18 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from ._abc import TimerRequest, InputStream, Context, Out  # NoQA
-from ._eventhub import EventHubEvent  # NoQA
-from ._eventgrid import EventGridEvent, EventGridOutputEvent  # NoQA
-from ._cosmosdb import Document, DocumentList  # NoQA
-from ._http import HttpRequest  # NoQA
-from ._http import HttpResponse  # NoQA
-from ._http_wsgi import WsgiMiddleware # NoQA
-from .kafka import KafkaEvent, KafkaConverter, KafkaTriggerConverter  # NoQA
-from ._queue import QueueMessage  # NoQA
-from ._servicebus import ServiceBusMessage  # NoQA
-from ._durable_functions import OrchestrationContext, EntityContext  # NoQA
-from .meta import get_binding_registry  # NoQA
+from ._abc import TimerRequest, InputStream, Context, Out
+from ._eventhub import EventHubEvent
+from ._eventgrid import EventGridEvent, EventGridOutputEvent
+from ._cosmosdb import Document, DocumentList
+from ._http import HttpRequest
+from ._http import HttpResponse
+from ._http_wsgi import WsgiMiddleware
+from .kafka import KafkaEvent, KafkaConverter, KafkaTriggerConverter
+from ._queue import QueueMessage
+from ._servicebus import ServiceBusMessage
+from ._durable_functions import OrchestrationContext, EntityContext
+from .meta import get_binding_registry
 
 # Import binding implementations to register them
 from . import blob  # NoQA
@@ -39,6 +39,7 @@ __all__ = (
     'Document',
     'DocumentList',
     'EventGridEvent',
+    'EventGridOutputEvent',
     'EventHubEvent',
     'HttpRequest',
     'HttpResponse',


### PR DESCRIPTION
I automated this PR by using [yesqa](https://github.com/asottile/yesqa) -- I'm also the maintainer of flake8

if a name is present in the `__all__` sequence, then you don't need to ignore the import with `# noqa`