### PR TITLE
Add message when ASGI and WSGI is enabled

### DIFF
--- a/azure/functions/_http_wsgi.py
+++ b/azure/functions/_http_wsgi.py
@@ -1,7 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from typing import Callable, Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any
+import logging
 from io import BytesIO, StringIO
 from os import linesep
 from urllib.parse import urlparse
@@ -142,17 +143,21 @@ class WsgiResponse:
 
 
 class WsgiMiddleware:
+    _logger = logging.getLogger('azure.functions.WsgiMiddleware')
+    _usage_reported = False
+
     def __init__(self, app):
+        if not self._usage_reported:
+            self._logger.info("Instantiating Azure Functions WSGI middleware.")
+            self._usage_reported = True
+
         self._app = app
         self._wsgi_error_buffer = StringIO()
-
         self.main = self._handle
 
     # Usage
     # return func.WsgiMiddleware(app).handle(req, context)
-    def handle(self,
-               req: HttpRequest,
-               context: Optional[Context] = None) -> HttpResponse:
+    def handle(self, req: HttpRequest, context: Optional[Context] = None):
         return self._handle(req, context)
 
     # Usage

--- a/azure/functions/_http_wsgi.py
+++ b/azure/functions/_http_wsgi.py
@@ -146,11 +146,7 @@ class WsgiMiddleware:
         self._app = app
         self._wsgi_error_buffer = StringIO()
 
-    # Usage
-    # main = func.WsgiMiddleware(app).main
-    @property
-    def main(self) -> Callable[[HttpRequest, Context], HttpResponse]:
-        return self._handle
+        self.main = self._handle
 
     # Usage
     # return func.WsgiMiddleware(app).handle(req, context)
@@ -159,9 +155,9 @@ class WsgiMiddleware:
                context: Optional[Context] = None) -> HttpResponse:
         return self._handle(req, context)
 
-    def _handle(self,
-                req: HttpRequest,
-                context: Optional[Context]) -> HttpResponse:
+    # Usage
+    # main = func.WsgiMiddleware(app).main
+    def _handle(self, req, context):
         wsgi_request = WsgiRequest(req, context)
         environ = wsgi_request.to_environ(self._wsgi_error_buffer)
         wsgi_response = WsgiResponse.from_app(self._app, environ)

--- a/tests/test_http_asgi.py
+++ b/tests/test_http_asgi.py
@@ -153,3 +153,18 @@ class TestHttpAsgiMiddleware(unittest.TestCase):
         # Verify asserted
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get_body(), test_body)
+
+    def test_middleware_wrapper(self):
+        app = MockAsgiApplication()
+        test_body = b'Hello world!'
+        app.response_body = test_body
+        app.response_code = 200
+        req = self._generate_func_request()
+        ctx = self._generate_func_context()
+
+        main = AsgiMiddleware(app).main
+        response = main(req, ctx)
+
+        # Verify asserted
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_body(), test_body)

--- a/tests/test_http_asgi.py
+++ b/tests/test_http_asgi.py
@@ -142,6 +142,11 @@ class TestHttpAsgiMiddleware(unittest.TestCase):
         self.assertEqual(response.get_body(), test_body)
 
     def test_middleware_calls_app_with_context(self):
+        """Test if the middleware can be used by exposing the .handle method,
+        specifically when the middleware is used as
+        def main(req, context):
+            return AsgiMiddleware(app).handle(req, context)
+        """
         app = MockAsgiApplication()
         test_body = b'Hello world!'
         app.response_body = test_body
@@ -155,6 +160,10 @@ class TestHttpAsgiMiddleware(unittest.TestCase):
         self.assertEqual(response.get_body(), test_body)
 
     def test_middleware_wrapper(self):
+        """Test if the middleware can be used by exposing the .main property,
+        specifically when the middleware is used as
+        main = AsgiMiddleware(app).main
+        """
         app = MockAsgiApplication()
         test_body = b'Hello world!'
         app.response_body = test_body

--- a/tests/test_http_wsgi.py
+++ b/tests/test_http_wsgi.py
@@ -164,6 +164,11 @@ class TestHttpWsgi(unittest.TestCase):
         self.assertEqual(e.exception.message, 'wsgi excpt')
 
     def test_middleware_handle(self):
+        """Test if the middleware can be used by exposing the .handle method,
+        specifically when the middleware is used as
+        def main(req, context):
+            return WsgiMiddleware(app).handle(req, context)
+        """
         app = self._generate_wsgi_app()
         func_request = self._generate_func_request()
         func_response = WsgiMiddleware(app).handle(func_request)
@@ -171,6 +176,10 @@ class TestHttpWsgi(unittest.TestCase):
         self.assertEqual(func_response.get_body(), b'sample string')
 
     def test_middleware_wrapper(self):
+        """Test if the middleware can be used by exposing the .main property,
+        specifically when the middleware is used as
+        main = WsgiMiddleware(app).main
+        """
         app = self._generate_wsgi_app()
         main = WsgiMiddleware(app).main
         func_request = self._generate_func_request()

--- a/tests/test_http_wsgi.py
+++ b/tests/test_http_wsgi.py
@@ -168,6 +168,16 @@ class TestHttpWsgi(unittest.TestCase):
         func_request = self._generate_func_request()
         func_response = WsgiMiddleware(app).handle(func_request)
         self.assertEqual(func_response.status_code, 200)
+        self.assertEqual(func_response.get_body(), b'sample string')
+
+    def test_middleware_wrapper(self):
+        app = self._generate_wsgi_app()
+        main = WsgiMiddleware(app).main
+        func_request = self._generate_func_request()
+        func_context = self._generate_func_context()
+        func_response = main(func_request, func_context)
+        self.assertEqual(func_response.status_code, 200)
+        self.assertEqual(func_response.get_body(), b'sample string')
 
     def _generate_func_request(
             self,


### PR DESCRIPTION
### Related Issues
Fix: https://github.com/Azure/azure-functions-python-library/issues/71
Fix: https://github.com/Azure/azure-functions-python-worker/issues/839

### Description
1. Now when the WSGI and ASGI middleware start, we will emit `Instantiating Azure Functions ASGI middleware.` or `Instantiating Azure Functions WSGI middleware.` log message for the very first time when the middleware instantiated either in `main = WsgiMiddleware(app)` syntax or `def func(req, context): return WsgiMiddleware(app).handle(req, context)` syntax.
2. Fix an issue where the middlewares fail to accept the context parameter.

### Todo
1. In the worker, we need to direct `azure.functions` log into system log category.

cc: @tonybaloney @stefanushinardi @vrdmr 