### PR TITLE
WSGI middleware should unquote path_info 

### DIFF
--- a/azure/functions/_http_wsgi.py
+++ b/azure/functions/_http_wsgi.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, Any
 import logging
 from io import BytesIO, StringIO
 from os import linesep
-from urllib.parse import urlparse
+from urllib.parse import urlparse, unquote_to_bytes
 from wsgiref.headers import Headers
 
 from ._abc import Context
@@ -30,7 +30,7 @@ class WsgiRequest:
         # Implement interfaces for PEP 3333 environ
         self.request_method = getattr(func_req, 'method', None)
         self.script_name = ''
-        self.path_info = getattr(url, 'path', None)
+        self.path_info = unquote_to_bytes(getattr(url, 'path', None)).decode('latin-1')
         self.query_string = getattr(url, 'query', None)
         self.content_type = self._lowercased_headers.get('content-type')
         self.content_length = str(len(func_req_body))


### PR DESCRIPTION
I believe that the environ PATH_INFO attribute should be unquoted when it is passed through. This is replicates the functionality of Gunicorn (https://github.com/pallets/werkzeug/blob/5a2bf35441006d832ab1ed5a31963cbc366c99ac/werkzeug/serving.py#L98) and Werkzeug (https://github.com/benoitc/gunicorn/blob/cf55d2cec277f220ebd605989ce78ad1bb553c46/gunicorn/http/wsgi.py#L184)

There is a more detailed explanation of this in the Gunicorn project - https://github.com/benoitc/gunicorn/pull/1211 - but in short PEP 333 implicitly describes restructuring the url - https://www.python.org/dev/peps/pep-3333/#url-reconstruction.

The reason for raising this is that I have a Flask app which exhibits different behaviour when running under Azure Functions via the wsgi middleware. I have raised the PR to demonstrate the logic of Gunicorn, but I am happy to open a debate on this functionality and alternatives as obviously a change could cause side effects for existing users currently expecting the path to be quoted. Perhaps an ability to toggle the unquoting behaviour as a caller would be more appropriate?