### PR TITLE
Expose the trace context from the worker

### DIFF
--- a/azure/functions/_abc.py
+++ b/azure/functions/_abc.py
@@ -24,6 +24,28 @@ class Out(abc.ABC, typing.Generic[T]):
         pass
 
 
+class TraceContext(abc.ABC):
+    """Function invocation trace context."""
+
+    @property
+    @abc.abstractmethod
+    def trace_parent(self) -> str:
+        """Function invocation trace parent."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def trace_state(self) -> str:
+        """Function invocation trace state."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def attributes(self) -> typing.Mapping[str, typing.Any]:
+        """Function invocation trace attributes."""
+        pass
+
+
 class Context(abc.ABC):
     """Function invocation context."""
 
@@ -43,6 +65,12 @@ class Context(abc.ABC):
     @abc.abstractmethod
     def function_directory(self) -> str:
         """Function directory."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def trace_context(self) -> TraceContext:
+        """Trace context."""
         pass
 
 


### PR DESCRIPTION
As best I can tell, this update will simply allow typed/known access to values that already exist but aren't yet exposed.

Having access to these values is very helpful for tracing instrumentation.

References:
https://github.com/Azure/azure-functions-python-worker/blob/main/azure_functions_worker/bindings/context.py
https://github.com/Azure/azure-functions-python-worker/blob/698c524db03b70b13fb42d17e7b986ea8f744b6d/azure_functions_worker/bindings/tracecontext.py
https://github.com/Azure/azure-functions-python-worker/pull/545/files#diff-4b26101cf19d671ade506a5f9623a651bd389240b020b6176061abca184b2b6e

<img width="602" alt="Screen Shot 2021-06-24 at 11 42 00 AM" src="https://user-images.githubusercontent.com/8225090/123292627-3a8d4900-d4e1-11eb-8b12-65cc8eb82382.png">
