### PR TITLE
Add type hints to `HttpResponse`

### DIFF
--- a/azure/functions/_http.py
+++ b/azure/functions/_http.py
@@ -70,8 +70,12 @@ class HttpResponse(_abc.HttpResponse):
         ``'utf-8'``.
     """
 
-    def __init__(self, body=None, *,
-                 status_code=None, headers=None, mimetype=None, charset=None):
+    def __init__(self,
+                 body: typing.Union[str, bytes] = None, *,
+                 status_code: int = None,
+                 headers: typing.Optional[typing.Mapping[str, str]] = None,
+                 mimetype: typing.Optional[str] = None,
+                 charset: str = None) -> None:
         if status_code is None:
             status_code = 200
         self.__status_code = status_code

--- a/azure/functions/_http_asgi.py
+++ b/azure/functions/_http_asgi.py
@@ -70,7 +70,7 @@ class AsgiResponse:
         return HttpResponse(
             body=b"".join(self._buffer),
             status_code=self._status_code,
-            headers=self._headers,
+            headers=self._headers,  # type: ignore
             mimetype=lowercased_headers.get("content-type"),
             charset=lowercased_headers.get("content-encoding"),
         )


### PR DESCRIPTION
It seems `HttpResponse` is the only class in this file that does not contain type hints.

This generates errors when client code is checked using `mypy` in strict mode:
```
error: Call to untyped function "HttpResponse" in typed context
```

Add type hints following the docstring.