### PR TITLE
Exclude azure from package build

### DIFF
--- a/.github/workflows/gh-tests-ci.yml
+++ b/.github/workflows/gh-tests-ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: [3.6, 3.7, 3.8, 3.9]
+        python_version: [3.6, 3.7, 3.8, 3.9, "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python_version }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,4 +9,4 @@
 # AZURE FUNCTIONS TEAM
 # For all file changes, github would automatically include the following people in the PRs.
 #
-* @anirudhgarg @Hazhzeng @vrdmr @AnatoliB
+* @anirudhgarg @vrdmr @gavin-aguiar

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 
 ## Overview
 
-Python support for Azure Functions is based on Python 3.6/3.7/3.8 and 3.9 (coming soon), serverless hosting on Linux and the Functions 2.0 runtime.
+Python support for Azure Functions is based on Python 3.6/3.7/3.8/3.9 and 3.10 (coming soon), serverless hosting on Linux and the Functions 2.0, 3.0
+and 4.0 runtime.
 
 Here is the current status of Python in Azure Functions:
 
@@ -16,7 +17,8 @@ _What are the supported Python versions?_
 |Azure Functions Runtime|Python 3.6|Python 3.7|Python 3.8|Python 3.9|
 |---|---|---|---|---|
 |Azure Functions 2.0|✔|✔|-|-|
-|Azure Functions 3.0|✔|✔|✔|(preview)|
+|Azure Functions 3.0|✔|✔|✔|✔|
+|Azure Functions 4.0|-|✔|✔|✔|
 
 _What's available?_
 - Build, test, debug and publish using Azure Functions Core Tools (CLI) or Visual Studio Code

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from setuptools import setup
+from setuptools import find_packages, setup
 from azure.functions import __version__
 
 with open("README.md") as readme:
@@ -30,11 +30,9 @@ setup(
         'Development Status :: 5 - Production/Stable',
     ],
     license='MIT',
-    packages=[
-        'azure.functions',
-        'azure.functions.extension',
-        'azure.functions._thirdparty'
-    ],
+    packages=find_packages(exclude=[
+        'azure'
+    ]),
     package_data={
         'azure.functions': ['py.typed']
     },


### PR DESCRIPTION
### Description:
Excluded azure from the packages. This fixes an issue where the azure functions version does not get updated when a version is specified in the functions requirements.txt file.
Reason for this is since azure directory has an __init.py__ file, including azure in the package build overrides the users dependencies. 