### PR TITLE
remove internal cosmosdb keys filtering

### DIFF
--- a/azure/functions/_cosmosdb.py
+++ b/azure/functions/_cosmosdb.py
@@ -7,10 +7,6 @@ import json
 from . import _abc
 
 
-# Internal properties of CosmosDB documents.
-_SYSTEM_KEYS = {'_etag', '_lsn', '_rid', '_self', '_ts'}
-
-
 class Document(_abc.Document, collections.UserDict):
     """An Azure Document.
 
@@ -25,8 +21,7 @@ class Document(_abc.Document, collections.UserDict):
     @classmethod
     def from_dict(cls, dct: dict) -> 'Document':
         """Create a Document from a dict object."""
-        filtered = {k: v for k, v in dct.items() if k not in _SYSTEM_KEYS}
-        return cls(filtered)
+        return cls({k: v for k, v in dct.items()})
 
     def to_json(self) -> str:
         """Return the JSON representation of the document."""

--- a/tests/test_cosmosdb.py
+++ b/tests/test_cosmosdb.py
@@ -66,6 +66,30 @@ class TestCosmosdb(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]['name'], None)
 
+    def test_cosmosdb_convert_json_internal_fields_assigned(self):
+        datum: Datum = Datum("""
+        {
+            "id": "1",
+            "name": null,
+            "_rid": "dummy12344",
+            "_self": "7U4=/docs/gpU4AJcm7U4KAAAAAAAAAA==/",
+            "_etag": "000-0500-0000-62598ff00000",
+            "_attachments": "attachments/",
+            "_ts": 1650036720
+        }
+        """, "json")
+        result: func.DocumentList = cdb.CosmosDBConverter.decode(
+            data=datum, trigger_metadata=None)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['name'], None)
+        self.assertEqual(result[0]['_rid'], "dummy12344")
+        self.assertEqual(result[0]['_self'],
+                         "7U4=/docs/gpU4AJcm7U4KAAAAAAAAAA==/")
+        self.assertEqual(result[0]['_etag'], "000-0500-0000-62598ff00000")
+        self.assertEqual(result[0]['_attachments'], "attachments/")
+        self.assertEqual(result[0]['_ts'], 1650036720)
+
     def test_cosmosdb_convert_json_multiple_entries(self):
         datum: Datum = Datum("""
         [


### PR DESCRIPTION
Change to address BUG: Cosmos DB Document should not be filtering _ts  address  https://github.com/Azure/azure-functions-python-library/issues/120