### PR TITLE
GH#107: Skip setting multi Set-Cookie headers for python 3.7

### DIFF
--- a/azure/functions/http.py
+++ b/azure/functions/http.py
@@ -2,6 +2,8 @@
 # Licensed under the MIT License.
 
 import json
+import logging
+import sys
 import typing
 from http.cookies import SimpleCookie
 
@@ -96,10 +98,17 @@ class HttpResponseConverter(meta.OutConverter, binding='http'):
                 datum_body = meta.Datum(type='bytes', value=b'')
 
             cookies = None
-            if "Set-Cookie" in headers:
-                cookies = [SimpleCookie(cookie) for cookie in
-                           headers.get_all('Set-Cookie')]
-                headers.pop("Set-Cookie")
+
+            if sys.version_info.major == 3 and sys.version_info.minor <= 7:
+                logging.warning(
+                    "Setting multiple 'Set-Cookie' response headers is not "
+                    "supported in Azure Python Function with python version "
+                    "3.7, please upgrade to python 3.8 or above.")
+            else:
+                if "Set-Cookie" in headers:
+                    cookies = [SimpleCookie(cookie) for cookie in
+                               headers.get_all('Set-Cookie')]
+                    headers.pop("Set-Cookie")
 
             return meta.Datum(
                 type='http',

--- a/azure/functions/http.py
+++ b/azure/functions/http.py
@@ -100,6 +100,11 @@ class HttpResponseConverter(meta.OutConverter, binding='http'):
             cookies = None
 
             if sys.version_info.major == 3 and sys.version_info.minor <= 7:
+                # SimpleCookie api in http.cookies - Python Standard Library
+                # is not supporting 'samesite' in cookie attribute in python
+                # 3.7 or below and would cause cookie parsing error
+                # https://docs.python.org/3/library/http.cookies.html
+                # ?msclkid=d78849ddcd7311ecadd81f2f51d08b8e
                 logging.warning(
                     "Setting multiple 'Set-Cookie' response headers is not "
                     "supported in Azure Python Function with python version "

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,7 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-
+import sys
 import unittest
+from unittest import skipIf
 
 import azure.functions as func
 import azure.functions.http as http
@@ -120,6 +121,24 @@ class TestHTTP(unittest.TestCase):
                          "Max-Age=10000000; Path=/")
 
         self.assertTrue("Set-Cookie" not in resp.headers)
+
+    @skipIf(sys.version_info >= (3, 8, 0),
+            "Skip the tests for Python 3.8 and above")
+    def test_http_response_encode_to_datum_with_cookies_in_python_3_7(self):
+        headers = HttpResponseHeaders()
+        headers.add("Set-Cookie",
+                    'foo3=42; Domain=example.com; Expires=Thu, '
+                    '12-Jan-2017 13:55:08 GMT; Path=/; Max-Age=10000000')
+        headers.add("Set-Cookie",
+                    'foo3=43; Domain=example.com; Expires=Thu, 12-Jan-2018 '
+                    '13:55:09 GMT; Path=/; Max-Age=10000000')
+        resp = func.HttpResponse(headers=headers)
+        datum = http.HttpResponseConverter.encode(resp, expected_type=None)
+
+        actual_cookies = datum.value['cookies']
+        self.assertIsNone(actual_cookies)
+        self.assertIn("Set-Cookie", resp.headers,
+                      "Set-Cookie header not present in response headers!")
 
     def test_http_response_encode_to_datum_with_cookies_lower_case(self):
         headers = HttpResponseHeaders()

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -96,6 +96,8 @@ class TestHTTP(unittest.TestCase):
 
         self.assertEqual(datum.value["cookies"], None)
 
+    @skipIf(sys.version_info < (3, 8, 0),
+            "Skip the tests for Python 3.7 and below")
     def test_http_response_encode_to_datum_with_cookies(self):
         headers = HttpResponseHeaders()
         headers.add("Set-Cookie",
@@ -140,6 +142,8 @@ class TestHTTP(unittest.TestCase):
         self.assertIn("Set-Cookie", resp.headers,
                       "Set-Cookie header not present in response headers!")
 
+    @skipIf(sys.version_info < (3, 8, 0),
+            "Skip the tests for Python 3.7 and below")
     def test_http_response_encode_to_datum_with_cookies_lower_case(self):
         headers = HttpResponseHeaders()
         headers.add("set-cookie",


### PR DESCRIPTION
Skipping setting multiple Set-Cookie headers as SimpleCookie which is a standard python lib api in python3.7 does not support samesite attribute and would cause cookie parsing error. (Ref: https://docs.python.org/3/library/http.cookies.html). A warning will be given to customers who uses python3.7 and tries to set multiple cookie headers.