### PR TITLE
[WIP] Add ujson as alternative JSON encoder

### DIFF
--- a/.github/workflows/gh-tests-ci.yml
+++ b/.github/workflows/gh-tests-ci.yml
@@ -30,7 +30,7 @@ jobs:
       name: Test with pytest and ujson
       run: |
         python -m pip install .[ujson]
-        pytest --cache-clear tests
+        pytest --cache-clear --cov=./azure --cov-report=xml --cov-branch --cov-append tests 
     - if: matrix.python_version == 3.9
       name: Codecov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/gh-tests-ci.yml
+++ b/.github/workflows/gh-tests-ci.yml
@@ -28,7 +28,7 @@ jobs:
         pytest --cache-clear --cov=./azure --cov-report=xml --cov-branch tests
     - name: Test with pytest and ujson
       run: |
-        python -m pip install ujson
+        python -m pip install .[ujson]
         pytest --cache-clear tests
     - name: Codecov
       if: ${{ matrix.python-version }} == 3.9

--- a/.github/workflows/gh-tests-ci.yml
+++ b/.github/workflows/gh-tests-ci.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         pytest --cache-clear --cov=./azure --cov-report=xml --cov-branch tests
     - name: Test with pytest and ujson
+      if: ${{ matrix.python-version }} > 3.6
       run: |
         python -m pip install .[ujson]
         pytest --cache-clear tests

--- a/.github/workflows/gh-tests-ci.yml
+++ b/.github/workflows/gh-tests-ci.yml
@@ -26,13 +26,13 @@ jobs:
     - name: Test with pytest
       run: |
         pytest --cache-clear --cov=./azure --cov-report=xml --cov-branch tests
-    - name: Test with pytest and ujson
-      if: ${{ matrix.python-version }} > 3.6
+    - if: matrix.python_version != 3.6
+      name: Test with pytest and ujson
       run: |
         python -m pip install .[ujson]
         pytest --cache-clear tests
-    - name: Codecov
-      if: ${{ matrix.python-version }} == 3.9
+    - if: matrix.python_version == 3.9
+      name: Codecov
       uses: codecov/codecov-action@v2
       with:
         file: ./coverage.xml

--- a/.github/workflows/gh-tests-ci.yml
+++ b/.github/workflows/gh-tests-ci.yml
@@ -26,6 +26,10 @@ jobs:
     - name: Test with pytest
       run: |
         pytest --cache-clear --cov=./azure --cov-report=xml --cov-branch tests
+    - name: Test with pytest and ujson
+      run: |
+        python -m pip install ujson
+        pytest --cache-clear tests
     - name: Codecov
       if: ${{ matrix.python-version }} == 3.9
       uses: codecov/codecov-action@v2

--- a/azure/functions/_cosmosdb.py
+++ b/azure/functions/_cosmosdb.py
@@ -2,8 +2,8 @@
 # Licensed under the MIT License.
 
 import collections
-import json
 
+from azure.functions import _json as json
 from . import _abc
 
 

--- a/azure/functions/_durable_functions.py
+++ b/azure/functions/_durable_functions.py
@@ -12,7 +12,7 @@ def _serialize_custom_object(obj):
 
     This function gets called when `json.dumps` cannot serialize
     an object and returns a serializable dictionary containing enough
-    metadata to recontrust the original object.
+    metadata to reconstruct the original object.
 
     Parameters
     ----------

--- a/azure/functions/_http.py
+++ b/azure/functions/_http.py
@@ -3,7 +3,7 @@
 
 import collections.abc
 import io
-import json
+
 import types
 import typing
 
@@ -12,6 +12,7 @@ from ._thirdparty.werkzeug import datastructures as _wk_datastructures
 from ._thirdparty.werkzeug import formparser as _wk_parser
 from ._thirdparty.werkzeug import http as _wk_http
 from ._thirdparty.werkzeug.datastructures import Headers
+from azure.functions import _json as json
 
 
 class BaseHeaders(collections.abc.Mapping):

--- a/azure/functions/_http_asgi.py
+++ b/azure/functions/_http_asgi.py
@@ -89,11 +89,18 @@ class AsgiResponse:
         # https://github.com/Azure/azure-functions-host/issues/4926
 
     async def _receive(self):
-        return {
-            "type": "http.request",
-            "body": self._request_body,
-            "more_body": False,
-        }
+        if self._request_body is not None:
+            reply = {
+                "type": "http.request",
+                "body": self._request_body,
+                "more_body": False,
+            }
+            self._request_body = None
+        else:
+            reply = {
+                "type": "http.disconnect",
+            }
+        return reply
 
     async def _send(self, message):
         logging.debug(f"Received {message} from ASGI worker.")

--- a/azure/functions/_json.py
+++ b/azure/functions/_json.py
@@ -3,7 +3,6 @@
 
 from enum import Enum
 import os
-import warnings
 
 try:
     import orjson

--- a/azure/functions/_json.py
+++ b/azure/functions/_json.py
@@ -57,5 +57,5 @@ if HAS_UJSON:
             return ujson.loads(s)
 
 else:
-    dumps = json.dumps # type: ignore
+    dumps = json.dumps  # type: ignore
     loads = json.loads

--- a/azure/functions/_json.py
+++ b/azure/functions/_json.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 from enum import Enum
+from typing import AnyStr, Any
 import os
 
 AZUREFUNCTIONS_UJSON_ENV_VAR = 'AZUREFUNCTIONS_UJSON'
@@ -40,21 +41,21 @@ class StringifyEnumJsonEncoder(json.JSONEncoder):
 JSONDecodeError = json.JSONDecodeError
 
 if HAS_UJSON:
-    def dumps(v, **kwargs):
+    def dumps(v: Any, **kwargs) -> str:
         if 'default' in kwargs:
             return json.dumps(v, **kwargs)
 
         if 'cls' in kwargs:
             del kwargs['cls']
-        
+
         return ujson.dumps(v, **kwargs)
 
-    def loads(*args, **kwargs):
+    def loads(s: AnyStr, **kwargs):
         if kwargs:
-            return json.loads(*args, **kwargs)
+            return json.loads(s, **kwargs)
         else:  # ujson takes no kwargs
-            return ujson.loads(*args)
+            return ujson.loads(s)
 
 else:
-    dumps = json.dumps
+    dumps = json.dumps # type: ignore
     loads = json.loads

--- a/azure/functions/_json.py
+++ b/azure/functions/_json.py
@@ -41,7 +41,7 @@ if HAS_ORJSON:
             del kwargs['sort_keys']
             sort_keys = True
         if kwargs:  # Unsupported arguments
-            return json.dumps(v, **kwargs)
+            return json.dumps(v, sort_keys=sort_keys, **kwargs)
         if sort_keys:
             r = orjson.dumps(v, option=orjson.OPT_SORT_KEYS)
         else:

--- a/azure/functions/_json.py
+++ b/azure/functions/_json.py
@@ -1,0 +1,59 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from enum import Enum
+import os
+import warnings
+
+try:
+    import orjson
+    if 'AZUREFUNCTIONS_ORJSON' in os.environ:
+        HAS_ORJSON = bool(os.environ['AZUREFUNCTIONS_ORJSON'])
+    else:
+        HAS_ORJSON = True
+    import json
+except ImportError:
+    import json
+    HAS_ORJSON = False
+
+
+class StringifyEnum(Enum):
+    """This class output name of enum object when printed as string."""
+
+    def __str__(self):
+        return str(self.name)
+
+
+class StringifyEnumJsonEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, StringifyEnum):
+            return str(o)
+
+        return super().default(o)
+
+
+JSONDecodeError = json.JSONDecodeError
+
+if HAS_ORJSON:
+    def dumps(v, **kwargs):
+        sort_keys = False
+        if 'sort_keys' in kwargs:
+            del kwargs['sort_keys']
+            sort_keys = True
+        if kwargs:  # Unsupported arguments
+            return json.dumps(v, **kwargs)
+        if sort_keys:
+            r = orjson.dumps(v, option=orjson.OPT_SORT_KEYS)
+        else:
+            r = orjson.dumps(v)
+        return r.decode(encoding='utf-8')
+
+    def loads(*args, **kwargs):
+        if kwargs:
+            return json.loads(*args, **kwargs)
+        else:  # ORjson takes no kwargs
+            return orjson.loads(*args)
+
+else:
+    dumps = json.dumps
+    loads = json.loads

--- a/azure/functions/_queue.py
+++ b/azure/functions/_queue.py
@@ -2,9 +2,10 @@
 # Licensed under the MIT License.
 
 import datetime
-import json
+
 import typing
 
+from azure.functions import _json as json
 from . import _abc
 
 

--- a/azure/functions/_sql.py
+++ b/azure/functions/_sql.py
@@ -2,8 +2,7 @@
 # Licensed under the MIT License.
 
 import collections
-import json
-
+from azure.functions import _json as json
 from . import _abc
 
 

--- a/azure/functions/cosmosdb.py
+++ b/azure/functions/cosmosdb.py
@@ -2,9 +2,10 @@
 # Licensed under the MIT License.
 
 import collections.abc
-import json
+
 import typing
 
+from azure.functions import _json as json
 from azure.functions import _cosmosdb as cdb
 
 from . import meta

--- a/azure/functions/decorators/utils.py
+++ b/azure/functions/decorators/utils.py
@@ -4,7 +4,6 @@ import inspect
 import re
 from abc import ABCMeta
 from enum import Enum
-from json import JSONEncoder
 from typing import TypeVar, Optional, Union, Iterable, Type, Callable
 
 T = TypeVar("T", bound=Enum)
@@ -12,12 +11,7 @@ SNAKE_CASE_RE = re.compile(r'^([a-z]+\d*_[a-z\d_]*|_+[a-z\d]+[a-z\d_]*)$',
                            re.IGNORECASE)
 WORD_RE = re.compile(r'^([a-z]+\d*)$', re.IGNORECASE)
 
-
-class StringifyEnum(Enum):
-    """This class output name of enum object when printed as string."""
-
-    def __str__(self):
-        return str(self.name)
+from azure.functions._json import StringifyEnum, StringifyEnumJsonEncoder  # NOQA
 
 
 class BuildDictMeta(type):
@@ -166,11 +160,3 @@ def is_word(input_string: str) -> bool:
     :return: True for one word string, false otherwise.
     """
     return WORD_RE.match(input_string) is not None
-
-
-class StringifyEnumJsonEncoder(JSONEncoder):
-    def default(self, o):
-        if isinstance(o, StringifyEnum):
-            return str(o)
-
-        return super().default(o)

--- a/azure/functions/durable_functions.py
+++ b/azure/functions/durable_functions.py
@@ -2,8 +2,8 @@
 # Licensed under the MIT License.
 
 import typing
-import json
 
+from azure.functions import _json as json
 from azure.functions import _durable_functions
 from . import meta
 

--- a/azure/functions/eventgrid.py
+++ b/azure/functions/eventgrid.py
@@ -3,9 +3,10 @@
 
 import collections
 import datetime
-import json
+
 from typing import Optional, List, Any, Dict, Union
 
+from azure.functions import _json as json
 from azure.functions import _eventgrid as azf_eventgrid
 
 from . import meta

--- a/azure/functions/eventhub.py
+++ b/azure/functions/eventhub.py
@@ -1,9 +1,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import json
+
 from typing import Dict, Any, List, Union, Optional, Mapping
 
+from azure.functions import _json as json
 from azure.functions import _eventhub
 
 from . import meta

--- a/azure/functions/extension/extension_meta.py
+++ b/azure/functions/extension/extension_meta.py
@@ -3,7 +3,8 @@
 
 from typing import Optional, Union, Dict, List
 import abc
-import json
+
+from azure.functions import _json as json
 from .app_extension_hooks import AppExtensionHooks
 from .func_extension_hooks import FuncExtensionHooks
 from .extension_hook_meta import ExtensionHookMeta

--- a/azure/functions/http.py
+++ b/azure/functions/http.py
@@ -1,13 +1,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import json
+
 import logging
 import sys
 import typing
 from http.cookies import SimpleCookie
 
 from azure.functions import _abc as azf_abc
+from azure.functions import _json as json
 from azure.functions import _http as azf_http
 from . import meta
 from ._thirdparty.werkzeug.datastructures import Headers

--- a/azure/functions/kafka.py
+++ b/azure/functions/kafka.py
@@ -2,12 +2,11 @@
 # Licensed under the MIT License.
 
 import typing
-import json
-
 from typing import Any, List
 
 from . import meta
 
+from azure.functions import _json as json
 from ._kafka import AbstractKafkaEvent
 
 

--- a/azure/functions/meta.py
+++ b/azure/functions/meta.py
@@ -4,7 +4,6 @@
 import abc
 import collections.abc
 import datetime
-import json
 import re
 from typing import Dict, Optional, Union, Tuple, Mapping, Any
 
@@ -13,6 +12,7 @@ from ._utils import (
     try_parse_datetime_with_formats,
     try_parse_timedelta_with_formats
 )
+from azure.functions import _json as json
 
 
 def is_iterable_type_annotation(annotation: object, pytype: object) -> bool:

--- a/azure/functions/queue.py
+++ b/azure/functions/queue.py
@@ -3,10 +3,10 @@
 
 import collections.abc
 import datetime
-import json
 from typing import List, Dict, Any, Union, Optional
 
 from azure.functions import _abc as azf_abc
+from azure.functions import _json as json
 from azure.functions import _queue as azf_queue
 
 from . import meta

--- a/azure/functions/servicebus.py
+++ b/azure/functions/servicebus.py
@@ -2,9 +2,9 @@
 # Licensed under the MIT License.
 
 import datetime
-import json
-from typing import Dict, Any, List, Union, Optional, Mapping, cast
 
+from typing import Dict, Any, List, Union, Optional, Mapping, cast
+from azure.functions import _json as json
 from azure.functions import _servicebus as azf_sbus
 
 from . import meta

--- a/azure/functions/sql.py
+++ b/azure/functions/sql.py
@@ -2,9 +2,9 @@
 # Licensed under the MIT License.
 
 import collections.abc
-import json
 import typing
 
+from azure.functions import _json as json
 from azure.functions import _sql as sql
 
 from . import meta

--- a/azure/functions/timer.py
+++ b/azure/functions/timer.py
@@ -1,10 +1,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import json
 import typing
 
 from azure.functions import _abc as azf_abc
+from azure.functions import _json as json
 from . import meta
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ EXTRA_REQUIRES = {
         'pytest-cov',
         'requests==2.*',
         'coverage'
-    ]
+    ],
+    'orjson': ['orjson>=3.6.8,<4.0']
 }
 
 with open("README.md") as readme:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ EXTRA_REQUIRES = {
         'pytest-cov',
         'pytest-benchmark',
         'requests==2.*',
-        'coverage'
+        'coverage',
+        'types-ujson'
     ],
     'ujson': ['ujson>=5.3.0,<6.0']
 }

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ EXTRA_REQUIRES = {
         'requests==2.*',
         'coverage'
     ],
-    'orjson': ['orjson>=3.6.8,<4.0']
+    'ujson': ['ujson>=5.3.0,<6.0']
 }
 
 with open("README.md") as readme:
@@ -36,6 +36,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
         'Operating System :: MacOS :: MacOS X',

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ EXTRA_REQUIRES = {
         'mypy',
         'pytest',
         'pytest-cov',
+        'pytest-benchmark',
         'requests==2.*',
         'coverage'
     ],

--- a/tests/decorators/test_function_app.py
+++ b/tests/decorators/test_function_app.py
@@ -1,9 +1,10 @@
 #  Copyright (c) Microsoft Corporation. All rights reserved.
 #  Licensed under the MIT License.
-import json
+
 import unittest
 from unittest import mock
 
+from azure.functions import _json as json
 from azure.functions import WsgiMiddleware, AsgiMiddleware
 from azure.functions.decorators.constants import HTTP_OUTPUT, HTTP_TRIGGER
 from azure.functions.decorators.core import DataType, AuthLevel, \

--- a/tests/decorators/test_utils.py
+++ b/tests/decorators/test_utils.py
@@ -219,3 +219,18 @@ class TestUtils(unittest.TestCase):
             Trigger.is_supported_trigger_type(
                 GenericTrigger(name='req', type="dummy"),
                 HttpTrigger))
+
+
+def test_clean_nones_nested_benchmark(benchmark):
+    data = [
+        {"direction": "IN", "type": "b", "name": "t1"},
+        {"direction": "IN", "type": "b", "name": "t2"},
+        {"direction": "IN", "type": "b", "name": "t3"},
+        {"direction": "IN", "type": "b", "name": "t4"},
+        {"direction": "IN", "type": "b", "name": "t5"},
+        {"direction": "IN", "type": "b", "name": "t6"},
+        {"direction": "IN", "type": "b", "name": "t7"},
+        {"direction": "IN", "type": "b", "name": "t8"},
+        {"direction": "IN", "type": "b", "name": "t9"}
+    ]
+    benchmark(BuildDictMeta.clean_nones, data)

--- a/tests/decorators/testutils.py
+++ b/tests/decorators/testutils.py
@@ -1,7 +1,7 @@
 #  Copyright (c) Microsoft Corporation. All rights reserved.
 #  Licensed under the MIT License.
-import json
 
+from azure.functions import _json as json
 from azure.functions.decorators.utils import StringifyEnumJsonEncoder
 
 

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -1,12 +1,12 @@
 #  Copyright (c) Microsoft Corporation. All rights reserved.
 #  Licensed under the MIT License.
-import json
 import unittest
 from typing import Any, Dict
 
 import azure.functions as func
 import azure.functions.blob as afb
 from azure.functions.blob import InputStream
+from azure.functions import _json as json
 from azure.functions.meta import Datum
 
 

--- a/tests/test_durable_functions.py
+++ b/tests/test_durable_functions.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 
 import unittest
-import json
 
 from azure.functions.durable_functions import (
     OrchestrationTriggerConverter,
@@ -13,6 +12,7 @@ from azure.functions._durable_functions import (
     OrchestrationContext,
     EntityContext
 )
+from azure.functions import _json as json
 from azure.functions.meta import Datum
 
 CONTEXT_CLASSES = [OrchestrationContext, EntityContext]

--- a/tests/test_eventhub.py
+++ b/tests/test_eventhub.py
@@ -3,12 +3,12 @@
 
 from typing import List, Mapping
 import unittest
-import json
 from unittest.mock import patch
 from datetime import datetime
 
 import azure.functions as func
 import azure.functions.eventhub as azf_eh
+from azure.functions import _json as json
 import azure.functions.meta as meta
 
 from .testutils import CollectionBytes, CollectionString
@@ -113,12 +113,14 @@ class TestEventHub(unittest.TestCase):
 
         self.assertEqual(result[0].enqueued_time, self.MOCKED_ENQUEUE_TIME)
         self.assertEqual(
-            result[0].get_body().decode('utf-8'), '{"device-status": "good1"}'
+            result[0].get_body().decode('utf-8'),
+            json.dumps({"device-status": "good1"})
         )
 
         self.assertEqual(result[1].enqueued_time, self.MOCKED_ENQUEUE_TIME)
         self.assertEqual(
-            result[1].get_body().decode('utf-8'), '{"device-status": "good2"}'
+            result[1].get_body().decode('utf-8'),
+            json.dumps({"device-status": "good2"})
         )
 
     def test_eventhub_trigger_multiple_events_collection_string(self):
@@ -131,12 +133,14 @@ class TestEventHub(unittest.TestCase):
 
         self.assertEqual(result[0].enqueued_time, self.MOCKED_ENQUEUE_TIME)
         self.assertEqual(
-            result[0].get_body().decode('utf-8'), '{"device-status": "good1"}'
+            result[0].get_body().decode('utf-8'),
+            json.dumps({"device-status": "good1"})
         )
 
         self.assertEqual(result[1].enqueued_time, self.MOCKED_ENQUEUE_TIME)
         self.assertEqual(
-            result[1].get_body().decode('utf-8'), '{"device-status": "good2"}'
+            result[1].get_body().decode('utf-8'),
+            json.dumps({"device-status": "good2"})
         )
 
     def test_eventhub_trigger_multiple_events_collection_bytes(self):
@@ -149,12 +153,14 @@ class TestEventHub(unittest.TestCase):
 
         self.assertEqual(result[0].enqueued_time, self.MOCKED_ENQUEUE_TIME)
         self.assertEqual(
-            result[0].get_body().decode('utf-8'), '{"device-status": "good1"}'
+            result[0].get_body().decode('utf-8'),
+            json.dumps({"device-status": "good1"})
         )
 
         self.assertEqual(result[1].enqueued_time, self.MOCKED_ENQUEUE_TIME)
         self.assertEqual(
-            result[1].get_body().decode('utf-8'), '{"device-status": "good2"}'
+            result[1].get_body().decode('utf-8'),
+            json.dumps({"device-status": "good2"})
         )
 
     def test_iothub_metadata_events(self):

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -7,6 +7,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 from logging import Logger
 
+from azure.functions import _json as json
 from azure.functions.extension import FunctionExtensionException
 from azure.functions.extension.app_extension_base import AppExtensionBase
 from azure.functions.extension.func_extension_base import FuncExtensionBase
@@ -152,7 +153,8 @@ class TestExtensionMeta(unittest.TestCase):
         info_json = self._instance.get_registered_extensions_json()
         self.assertEqual(
             info_json,
-            r'{"FuncExtension": {"HttpTrigger": ["NewFuncExtension"]}}'
+            json.dumps({"FuncExtension":
+                        {"HttpTrigger": ["NewFuncExtension"]}})
         )
 
     def test_get_registered_extension_json_application_ext(self):
@@ -164,7 +166,7 @@ class TestExtensionMeta(unittest.TestCase):
         info_json = self._instance.get_registered_extensions_json()
         self.assertEqual(
             info_json,
-            r'{"AppExtension": ["NewAppExtension"]}'
+            json.dumps({"AppExtension": ["NewAppExtension"]})
         )
 
     def test_get_extension_scope(self):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -169,7 +169,7 @@ class TestHTTP(unittest.TestCase):
 
 
 def test_http_request_body_json(benchmark):
-    data: bytes = b'{ "result": "OK", "message": "Everything is ok", "code": 200 }'
+    data: bytes = b'{ "result": "OK", "message": "All good!", "code": 200 }'
     request = func.HttpRequest(
         method='POST',
         url='/foo',

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -166,3 +166,17 @@ class TestHTTP(unittest.TestCase):
         self.assertIsNone(
             getattr(http.HttpResponseConverter, 'has_implicit_output', None)
         )
+
+
+def test_http_request_body_json(benchmark):
+    data: bytes = b'{ "result": "OK", "message": "Everything is ok", "code": 200 }'
+    request = func.HttpRequest(
+        method='POST',
+        url='/foo',
+        body=data,
+        headers={
+            'Content-Type': 'application/json; charset=utf-8'
+        }
+    )
+
+    benchmark(request.get_json)

--- a/tests/test_http_asgi.py
+++ b/tests/test_http_asgi.py
@@ -65,6 +65,9 @@ class MockAsgiApplication:
         assert isinstance(self.received_request['body'], bytes)
         assert isinstance(self.received_request['more_body'], bool)
 
+        self.next_request = await receive()
+        assert self.next_request['type'] == 'http.disconnect'
+
         await send(
             {
                 "type": "http.response.start",

--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -3,10 +3,10 @@
 
 from typing import List
 import unittest
-import json
 
 from unittest.mock import patch
 import azure.functions as func
+from azure.functions import _json as json
 import azure.functions.kafka as azf_ka
 import azure.functions.meta as meta
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,9 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import json
 import unittest
 
+from azure.functions import _json as json
 import azure.functions as func
 import azure.functions.queue as azf_q
 

--- a/tests/test_servicebus.py
+++ b/tests/test_servicebus.py
@@ -2,11 +2,12 @@
 # Licensed under the MIT License.
 
 from typing import Dict, List
-import json
+
 import unittest
 from datetime import datetime, timedelta
 
 import azure.functions as func
+from azure.functions import _json as json
 import azure.functions.servicebus as azf_sb
 from azure.functions import meta
 

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -6,7 +6,7 @@ import unittest
 import azure.functions as func
 import azure.functions.sql as sql
 from azure.functions.meta import Datum
-import json
+from azure.functions import _json as json
 
 
 class TestSql(unittest.TestCase):

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -1,9 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import json
 import unittest
-
+from azure.functions import _json as json
 import azure.functions.timer as timer
 from azure.functions.meta import Datum
 


### PR DESCRIPTION
The standard library `json` module is the slowest of the json encoders.

ujson is 10-20x faster at encoding and decoding, especially for large datasets.

This PR moves the `json` imports into a shim module, which picks the standard library implementation or ujson depending on whether:

- The user has installed ujson
- The user hasn't disabled it via an environment variable