### PR TITLE
Run startup and shutdown before handle http request

### DIFF
--- a/azure/functions/_http_asgi.py
+++ b/azure/functions/_http_asgi.py
@@ -166,9 +166,11 @@ class AsgiMiddleware:
     def _handle(self, req, context):
         asgi_request = AsgiRequest(req, context)
         asyncio.set_event_loop(self._loop)
+        self._loop.run_until_complete(self._app.router.startup())
         scope = asgi_request.to_asgi_http_scope()
         asgi_response = self._loop.run_until_complete(
             AsgiResponse.from_app(self._app, scope, req.get_body())
         )
+        self._loop.run_until_complete(self._app.router.shutdown())
 
         return asgi_response.to_func_response()


### PR DESCRIPTION
We're using this diff to work with a [stac-fastapi](https://github.com/stac-utils/stac-fastapi) app that needs to set up and tear down a DB connection for each request.

I'm not sure how generic this API is supposed to be, but this should definitely work with any Starlette implementation (relevant `startup` code [here](https://github.com/encode/starlette/blob/bc61505faef15b673bf4bf65db4927daa354d6b8/starlette/routing.py#L616-L624).

Fully understand if the scope for this library is broader, I haven't done much due diligence.