### PR TITLE
Fixing the Key decode issue for multi-events 

### DIFF
--- a/azure/functions/kafka.py
+++ b/azure/functions/kafka.py
@@ -262,8 +262,7 @@ class KafkaTriggerConverter(KafkaConverter,
             event = KafkaEvent(
                 body=parsed_data[i],
                 timestamp=parsed_timestamp_props[i],
-                key=cls._decode_typed_data(
-                    parsed_key_props[i], python_type=str),
+                key=parsed_key_props[i],
                 partition=parsed_partition_props[i],
                 offset=parsed_offset_props[i],
                 topic=parsed_topic_props[i],

--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -22,10 +22,12 @@ class Kafka(unittest.TestCase):
     MULTIPLE_KAFKA_TIMESTAMP_1 = "2020-06-20T05:06:25.945Z"
     MULTIPLE_KAFKA_DATA_0 = '{"Offset":62,"Partition":1,"Topic":"message",'\
         '"Timestamp":"2020-06-20T05:06:25.139Z","Value":"a", ' \
-                            '"Headers":[{"Key":"test","Value":"1"}], "Key" : "1"}'
+                            '"Headers":[{"Key":"test","Value":"1"}], ' \
+                            '"Key" : "1"}'
     MULTIPLE_KAFKA_DATA_1 = '{"Offset":63,"Partition":1,"Topic":"message",'\
         '"Timestamp":"2020-06-20T05:06:25.945Z","Value":"a", ' \
-                            '"Headers":[{"Key":"test2","Value":"2"}], "Key": "2"}'
+                            '"Headers":[{"Key":"test2","Value":"2"}], ' \
+                            '"Key": "2"}'
 
     def test_kafka_input_type(self):
         check_input_type = (

--- a/tests/test_kafka.py
+++ b/tests/test_kafka.py
@@ -22,10 +22,10 @@ class Kafka(unittest.TestCase):
     MULTIPLE_KAFKA_TIMESTAMP_1 = "2020-06-20T05:06:25.945Z"
     MULTIPLE_KAFKA_DATA_0 = '{"Offset":62,"Partition":1,"Topic":"message",'\
         '"Timestamp":"2020-06-20T05:06:25.139Z","Value":"a", ' \
-                            '"Headers":[{"Key":"test","Value":"1"}]}'
+                            '"Headers":[{"Key":"test","Value":"1"}], "Key" : "1"}'
     MULTIPLE_KAFKA_DATA_1 = '{"Offset":63,"Partition":1,"Topic":"message",'\
         '"Timestamp":"2020-06-20T05:06:25.945Z","Value":"a", ' \
-                            '"Headers":[{"Key":"test2","Value":"2"}]}'
+                            '"Headers":[{"Key":"test2","Value":"2"}], "Key": "2"}'
 
     def test_kafka_input_type(self):
         check_input_type = (
@@ -238,10 +238,10 @@ class Kafka(unittest.TestCase):
     def _generate_multiple_kafka_data(self, data_type='json'):
         data = '[{"Offset":62,"Partition":1,"Topic":"message",'\
                '"Timestamp":"2020-06-20T05:06:25.139Z","Value":"a",' \
-               ' "Headers":[{"Key":"test","Value":"1"}]},'\
+               ' "Headers":[{"Key":"test","Value":"1"}], "Key": "1"},'\
                ' {"Offset":63,"Partition":1,"Topic":"message",'\
                '"Timestamp":"2020-06-20T05:06:25.945Z","Value":"a", ' \
-               '"Headers":[{"Key":"test2","Value":"2"}]}]'
+               '"Headers":[{"Key":"test2","Value":"2"}], "Key": "2"}]'
         if data_type == 'collection_bytes':
             data = list(
                 map(lambda x: json.dumps(x).encode('utf-8'),
@@ -282,7 +282,7 @@ class Kafka(unittest.TestCase):
         }
 
     def _generate_multiple_trigger_metadata(self):
-        key_array = [None, None]
+        key_array = ["1", "2"]
         partition_array = [1, 2]
         timestamp_array = ["2020-06-20T05:06:25.139Z",
                            "2020-06-20T05:06:25.945Z"]


### PR DESCRIPTION
We were retrieving the key value for the case of multi-event from the already retrieved data, due to which customer was facing the crash in their basic scenario.
Customer has raised this issue multiple times -- https://github.com/Azure/azure-functions-kafka-extension/issues/388 