### PR TITLE
Implement read1 method for InputStream

### DIFF
--- a/azure/functions/blob.py
+++ b/azure/functions/blob.py
@@ -45,6 +45,9 @@ class InputStream(azf_abc.InputStream):
     def read(self, size=-1) -> bytes:
         return self._io.read(size)
 
+    def read1(self, size: int = -1) -> bytes:
+        return self.read(size)
+
     def readable(self) -> bool:
         return True
 

--- a/azure/functions/blob.py
+++ b/azure/functions/blob.py
@@ -45,8 +45,8 @@ class InputStream(azf_abc.InputStream):
     def read(self, size=-1) -> bytes:
         return self._io.read(size)
 
-    def read1(self, size: int = -1) -> bytes:
-        return self.read(size)
+    # implemented read1 method using aliasing.
+    read1 = read
 
     def readable(self) -> bool:
         return True

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -166,6 +166,20 @@ class TestBlob(unittest.TestCase):
 
         self.assertEqual(result.read(size=3), b'blo')
 
+    def test_blob_incomplete_read1(self):
+        datum: Datum = Datum(value=b'blob_content', type='bytes')
+        result: InputStream = afb.BlobConverter.decode(
+            data=datum, trigger_metadata=None)
+
+        self.assertEqual(result.read1(size=3), b'blo')
+
+    def test_blob_complete_read1(self):
+        datum: Datum = Datum(value=b'blob_content', type='bytes')
+        result: InputStream = afb.BlobConverter.decode(
+            data=datum, trigger_metadata=None)
+
+        self.assertEqual(result.read1(), b'blob_content')
+
     def test_blob_output_custom_output_content(self):
         class CustomOutput:
             def read(self) -> bytes:


### PR DESCRIPTION
Implementing read1 method for InputStream which enables support for libraries like pandas to pass InputStream Directly.
Fixes: https://github.com/Azure/azure-functions-python-library/issues/92