### PR TITLE
Drop 3.6 and add 3.11 to test matrix

### DIFF
--- a/.github/workflows/gh-tests-ci.yml
+++ b/.github/workflows/gh-tests-ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python_version: [3.7, 3.8, 3.9, "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python_version }}


### PR DESCRIPTION
3.6 isn't supported on Azure Functions anymore and 3.11 is planned for release soon