### PR TITLE
Added support for http.HTTPStatus in HTTPResponse

### DIFF
--- a/azure/functions/_http.py
+++ b/azure/functions/_http.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import collections.abc
+import http
 import io
 import json
 import types
@@ -67,12 +68,14 @@ class HttpResponse(_abc.HttpResponse):
 
     def __init__(self,
                  body: typing.Optional[typing.Union[str, bytes]] = None, *,
-                 status_code: typing.Optional[int] = None,
+                 status_code: typing.Optional[typing.Union[http.HTTPStatus, int]] = None,
                  headers: typing.Optional[typing.Mapping[str, str]] = None,
                  mimetype: typing.Optional[str] = None,
                  charset: typing.Optional[str] = None) -> None:
         if status_code is None:
             status_code = 200
+        if isinstance(status_code , http.HTTPStatus):
+            status_code = status_code.value
         self.__status_code = status_code
 
         if mimetype is None:

--- a/azure/functions/_http.py
+++ b/azure/functions/_http.py
@@ -53,6 +53,7 @@ class HttpResponse(_abc.HttpResponse):
 
     :param int status_code:
         Response status code.  If not specified, defaults to 200.
+        You can use an int status code or an http.HTTPStatus value
 
     :param dict headers:
         An optional mapping containing response HTTP headers.
@@ -68,13 +69,15 @@ class HttpResponse(_abc.HttpResponse):
 
     def __init__(self,
                  body: typing.Optional[typing.Union[str, bytes]] = None, *,
-                 status_code: typing.Optional[typing.Union[http.HTTPStatus, int]] = None,
+                 status_code: typing.Optional[typing.Union[
+                     http.HTTPStatus, int
+                 ]] = None,
                  headers: typing.Optional[typing.Mapping[str, str]] = None,
                  mimetype: typing.Optional[str] = None,
                  charset: typing.Optional[str] = None) -> None:
         if status_code is None:
             status_code = 200
-        if isinstance(status_code , http.HTTPStatus):
+        if isinstance(status_code, http.HTTPStatus):
             status_code = status_code.value
         self.__status_code = status_code
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,13 +1,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 import sys
-import unittest
-from unittest import skipIf
 import types
+import unittest
+from http import HTTPStatus
+from unittest import skipIf
+
 import azure.functions as func
 import azure.functions.http as http
-from azure.functions._http import HttpResponseHeaders, HttpRequestHeaders
-
+from azure.functions._http import HttpRequestHeaders, HttpResponseHeaders
 from azure.functions.meta import Datum
 
 
@@ -177,6 +178,12 @@ class TestHTTP(unittest.TestCase):
         self.assertIsNone(
             getattr(http.HttpResponseConverter, 'has_implicit_output', None)
         )
+
+    def test_http_response_accepts_http_enums(self):
+        response = func.HttpResponse(status_code=404)
+        self.assertEquals(response.status_code, 404)
+        response = func.HttpResponse(status_code=HTTPStatus.ACCEPTED)
+        self.assertEquals(response.status_code, 202)
 
     def test_http_request_converter_decode(self):
         data = {


### PR DESCRIPTION
It should be possible to pass values from the standard library http.HTTPStatus enum to HTTPResponse