### PR TITLE
Fix decorator typehints

### DIFF
--- a/azure/functions/decorators/function_app.py
+++ b/azure/functions/decorators/function_app.py
@@ -349,8 +349,8 @@ class TriggerApi(DecoratorApi, ABC):
               methods: Optional[
                   Union[Iterable[str], Iterable[HttpMethod]]] = None,
               auth_level: Optional[Union[AuthLevel, str]] = None,
-              trigger_extra_fields: Dict = {},
-              binding_extra_fields: Dict = {}
+              trigger_extra_fields: Dict[str, Any] = {},
+              binding_extra_fields: Dict[str, Any] = {}
               ) -> Callable[..., Any]:
         """The route decorator adds :class:`HttpTrigger` and
         :class:`HttpOutput` binding to the :class:`FunctionBuilder` object

--- a/azure/functions/decorators/function_app.py
+++ b/azure/functions/decorators/function_app.py
@@ -405,7 +405,7 @@ class TriggerApi(DecoratorApi, ABC):
                  run_on_startup: Optional[bool] = None,
                  use_monitor: Optional[bool] = None,
                  data_type: Optional[Union[DataType, str]] = None,
-                 **kwargs) -> Callable[..., Any]:
+                 **kwargs: Any) -> Callable[..., Any]:
         """The schedule decorator adds :class:`TimerTrigger` to the
         :class:`FunctionBuilder` object
         for building :class:`Function` object used in worker function
@@ -457,7 +457,7 @@ class TriggerApi(DecoratorApi, ABC):
             access_rights: Optional[Union[AccessRights, str]] = None,
             is_sessions_enabled: Optional[bool] = None,
             cardinality: Optional[Union[Cardinality, str]] = None,
-            **kwargs) -> Callable[..., Any]:
+            **kwargs: Any) -> Callable[..., Any]:
         """The on_service_bus_queue_change decorator adds
         :class:`ServiceBusQueueTrigger` to the :class:`FunctionBuilder` object
         for building :class:`Function` object used in worker function
@@ -516,7 +516,7 @@ class TriggerApi(DecoratorApi, ABC):
             access_rights: Optional[Union[AccessRights, str]] = None,
             is_sessions_enabled: Optional[bool] = None,
             cardinality: Optional[Union[Cardinality, str]] = None,
-            **kwargs) -> Callable[..., Any]:
+            **kwargs: Any) -> Callable[..., Any]:
         """The on_service_bus_topic_change decorator adds
         :class:`ServiceBusTopicTrigger` to the :class:`FunctionBuilder` object
         for building :class:`Function` object used in worker function
@@ -624,7 +624,7 @@ class TriggerApi(DecoratorApi, ABC):
                                       Union[Cardinality, str]] = None,
                                   consumer_group: Optional[
                                       str] = None,
-                                  **kwargs) -> Callable[..., Any]:
+                                  **kwargs: Any) -> Callable[..., Any]:
         """The event_hub_message_trigger decorator adds
         :class:`EventHubTrigger`
         to the :class:`FunctionBuilder` object
@@ -697,7 +697,7 @@ class TriggerApi(DecoratorApi, ABC):
                           preferred_locations: Optional[str] = None,
                           data_type: Optional[
                               Union[DataType, str]] = None,
-                          **kwargs) -> \
+                          **kwargs: Any) -> \
             Callable[..., Any]:
         """The cosmos_db_trigger decorator adds :class:`CosmosDBTrigger`
         to the :class:`FunctionBuilder` object


### PR DESCRIPTION
This fixes other type hints not covered by https://github.com/Azure/azure-functions-python-library/pull/160. https://github.com/Azure/azure-functions-python-library/pull/160 fixed all the callable related type hints, but some decorators do not have their type hints fully defined.

The main issue is https://github.com/Azure/azure-functions-python-worker/issues/1161