### PR TITLE
Added support for CosmosDB v4 extension

### DIFF
--- a/azure/functions/decorators/cosmosdb.py
+++ b/azure/functions/decorators/cosmosdb.py
@@ -1,5 +1,6 @@
 #  Copyright (c) Microsoft Corporation. All rights reserved.
 #  Licensed under the MIT License.
+from datetime import time
 from typing import Optional, Union
 
 from azure.functions.decorators.constants import COSMOS_DB, COSMOS_DB_TRIGGER
@@ -7,7 +8,7 @@ from azure.functions.decorators.core import DataType, InputBinding, \
     OutputBinding, Trigger
 
 
-class CosmosDBInput(InputBinding):
+class CosmosDBInputV3(InputBinding):
     @staticmethod
     def get_binding_name() -> str:
         return COSMOS_DB
@@ -31,7 +32,7 @@ class CosmosDBInput(InputBinding):
         super().__init__(name=name, data_type=data_type)
 
 
-class CosmosDBOutput(OutputBinding):
+class CosmosDBOutputV3(OutputBinding):
     @staticmethod
     def get_binding_name() -> str:
         return COSMOS_DB
@@ -59,7 +60,7 @@ class CosmosDBOutput(OutputBinding):
         super().__init__(name=name, data_type=data_type)
 
 
-class CosmosDBTrigger(Trigger):
+class CosmosDBTriggerV3(Trigger):
     @staticmethod
     def get_binding_name() -> str:
         return COSMOS_DB_TRIGGER
@@ -105,4 +106,104 @@ class CosmosDBTrigger(Trigger):
         self.connection_string_setting = connection_string_setting
         self.database_name = database_name
         self.collection_name = collection_name
+        super().__init__(name=name, data_type=data_type)
+
+
+class CosmosDBInput(InputBinding):
+    @staticmethod
+    def get_binding_name() -> str:
+        return COSMOS_DB
+
+    def __init__(self,
+                 name: str,
+                 connection: str,
+                 database_name: str,
+                 container_name: str,
+                 partition_key: Optional[str] = None,
+                 data_type: Optional[DataType] = None,
+                 id: Optional[str] = None,
+                 sql_query: Optional[str] = None,
+                 preferred_locations: Optional[str] = None,
+                 **kwargs):
+        self.database_name = database_name
+        self.container_name = container_name
+        self.connection = connection
+        self.partition_key = partition_key
+        self.id = id
+        self.sql_query = sql_query
+        self.preferred_locations = preferred_locations
+        super().__init__(name=name, data_type=data_type)
+
+
+class CosmosDBOutput(OutputBinding):
+    @staticmethod
+    def get_binding_name() -> str:
+        return COSMOS_DB
+
+    def __init__(self,
+                 name: str,
+                 connection: str,
+                 database_name: str,
+                 container_name: str,
+                 create_if_not_exists: Optional[bool] = None,
+                 partition_key: Optional[str] = None,
+                 container_throughput: Optional[int] = None,
+                 preferred_locations: Optional[str] = None,
+                 data_type: Optional[DataType] = None,
+                 **kwargs):
+        self.connection = connection
+        self.database_name = database_name
+        self.container_name = container_name
+        self.create_if_not_exists = create_if_not_exists
+        self.partition_key = partition_key
+        self.container_throughput = container_throughput
+        self.preferred_locations = preferred_locations
+        super().__init__(name=name, data_type=data_type)
+
+
+class CosmosDBTrigger(Trigger):
+    @staticmethod
+    def get_binding_name() -> str:
+        return COSMOS_DB_TRIGGER
+
+    def __init__(self,
+                 name: str,
+                 connection: str,
+                 database_name: str,
+                 container_name: str,
+                 lease_connection: Optional[str] = None,
+                 lease_database_name: Optional[str] = None,
+                 lease_container_name: Optional[str] = None,
+                 create_lease_container_if_not_exists: Optional[
+                     bool] = None,
+                 leases_container_throughput: Optional[int] = None,
+                 lease_container_prefix: Optional[str] = None,
+                 feed_poll_delay: Optional[int] = None,
+                 lease_acquire_interval: Optional[int] = None,
+                 lease_expiration_interval: Optional[int] = None,
+                 lease_renew_interval: Optional[int] = None,
+                 max_items_per_invocation: Optional[int] = None,
+                 start_from_beginning: Optional[time] = None,
+                 start_from_time: Optional[time] = None,
+                 preferred_locations: Optional[str] = None,
+                 data_type: Optional[Union[DataType]] = None,
+                 **kwargs):
+        self.connection = connection
+        self.database_name = database_name
+        self.container_name = container_name
+        self.lease_connection = lease_connection
+        self.lease_database_name = lease_database_name
+        self.lease_container_name = lease_container_name
+        self.create_lease_container_if_not_exists = \
+            create_lease_container_if_not_exists
+        self.leases_container_throughput = leases_container_throughput
+        self.lease_container_prefix = lease_container_prefix
+        self.feed_poll_delay = feed_poll_delay
+        self.lease_acquire_interval = lease_acquire_interval
+        self.lease_expiration_interval = lease_expiration_interval
+        self.lease_renew_interval = lease_renew_interval
+        self.max_items_per_invocation = max_items_per_invocation
+        self.start_from_beginning = start_from_beginning
+        self.start_from_time = start_from_time
+        self.preferred_locations = preferred_locations
         super().__init__(name=name, data_type=data_type)

--- a/azure/functions/decorators/cosmosdb.py
+++ b/azure/functions/decorators/cosmosdb.py
@@ -8,6 +8,7 @@ from azure.functions.decorators.core import DataType, InputBinding, \
     OutputBinding, Trigger
 
 
+#  Used by cosmos_db_input_v3
 class CosmosDBInputV3(InputBinding):
     @staticmethod
     def get_binding_name() -> str:
@@ -32,6 +33,7 @@ class CosmosDBInputV3(InputBinding):
         super().__init__(name=name, data_type=data_type)
 
 
+#  Used by cosmos_db_output_v3
 class CosmosDBOutputV3(OutputBinding):
     @staticmethod
     def get_binding_name() -> str:
@@ -60,6 +62,7 @@ class CosmosDBOutputV3(OutputBinding):
         super().__init__(name=name, data_type=data_type)
 
 
+# Used by cosmos_db_output_v3
 class CosmosDBTriggerV3(Trigger):
     @staticmethod
     def get_binding_name() -> str:
@@ -109,6 +112,7 @@ class CosmosDBTriggerV3(Trigger):
         super().__init__(name=name, data_type=data_type)
 
 
+#  Used by cosmos_db_input
 class CosmosDBInput(InputBinding):
     @staticmethod
     def get_binding_name() -> str:
@@ -135,6 +139,7 @@ class CosmosDBInput(InputBinding):
         super().__init__(name=name, data_type=data_type)
 
 
+#  Used by cosmos_db_output
 class CosmosDBOutput(OutputBinding):
     @staticmethod
     def get_binding_name() -> str:
@@ -161,6 +166,7 @@ class CosmosDBOutput(OutputBinding):
         super().__init__(name=name, data_type=data_type)
 
 
+#  Used by cosmos_db_trigger
 class CosmosDBTrigger(Trigger):
     @staticmethod
     def get_binding_name() -> str:

--- a/azure/functions/decorators/function_app.py
+++ b/azure/functions/decorators/function_app.py
@@ -747,7 +747,7 @@ class TriggerApi(DecoratorApi, ABC):
         for building :class:`Function` object used in worker function
         indexing model. This decorator will work only with extension bundle 2.x
         or 3.x. For additional details, please refer
-        https://github.com/Azure/azure-functions-python-worker/issues/1222.
+        https://aka.ms/cosmosdb-v4-update.
         This is equivalent to defining CosmosDBTrigger in the function.json
          which enables function to be triggered when CosmosDB data is changed.
         All optional fields will be given default value by function host when
@@ -871,13 +871,13 @@ class TriggerApi(DecoratorApi, ABC):
         for building :class:`Function` object used in worker function
         indexing model. This decorator will work only with extension bundle 4.x
         and above. For additional details, please refer
-        https://github.com/Azure/azure-functions-python-worker/issues/1222.
+        https://aka.ms/cosmosdb-v4-update.
         This is equivalent to defining CosmosDBTrigger in the function.json
         which enables function to be triggered when CosmosDB data is changed.
         All optional fields will be given default value by function host when
         they are parsed by function host.
 
-        Ref: https://aka.ms/azure-function-binding-cosmosdb-v2
+        Ref: https://aka.ms/azure-function-binding-cosmosdb-v4
 
         :param arg_name: The name of the variable that represents
         :class:`DocumentList` object in function code
@@ -1327,7 +1327,7 @@ class BindingApi(DecoratorApi, ABC):
         for building :class:`Function` object used in worker function
         indexing model. This decorator will work only with extension bundle 2.x
         or 3.x. For additional details, please refer
-        https://github.com/Azure/azure-functions-python-worker/issues/1222.
+        https://aka.ms/cosmosdb-v4-update.
          This is equivalent to defining CosmosDBOutput
         in the function.json which enables function to write to the CosmosDB.
         All optional fields will be given default value by function host when
@@ -1403,13 +1403,13 @@ class BindingApi(DecoratorApi, ABC):
         for building :class:`Function` object used in worker function
         indexing model. This decorator will work only with extension bundle 4.x
         and above. For additional details, please refer
-        https://github.com/Azure/azure-functions-python-worker/issues/1222.
+        https://aka.ms/cosmosdb-v4-update.
         This is equivalent to defining CosmosDBOutput
         in the function.json which enables function to write to the CosmosDB.
         All optional fields will be given default value by function host when
         they are parsed by function host.
 
-        Ref: https://aka.ms/azure-function-binding-cosmosdb-v2
+        Ref: https://aka.ms/azure-function-binding-cosmosdb-v4
 
         :param arg_name: The name of the variable that represents CosmosDB
         output object in function code.
@@ -1476,7 +1476,7 @@ class BindingApi(DecoratorApi, ABC):
         for building :class:`Function` object used in worker function
         indexing model. This decorator will work only with extension bundle 2.x
         or 3.x. For additional details, please refer
-        https://github.com/Azure/azure-functions-python-worker/issues/1222.
+        https://aka.ms/cosmosdb-v4-update.
         This is equivalent to defining CosmosDBInput
         in the function.json which enables function to read from CosmosDB.
         All optional fields will be given default value by function host when
@@ -1543,13 +1543,13 @@ class BindingApi(DecoratorApi, ABC):
         for building :class:`Function` object used in worker function
         indexing model. This decorator will work only with extension bundle 4.x
         and above. For additional details, please refer
-        https://github.com/Azure/azure-functions-python-worker/issues/1222.
+        https://aka.ms/cosmosdb-v4-update.
         This is equivalent to defining CosmosDBInput in the function.json which
          enables function to read from CosmosDB.
         All optional fields will be given default value by function host when
         they are parsed by function host.
 
-        Ref: https://aka.ms/azure-function-binding-cosmosdb-v2
+        Ref: https://aka.ms/azure-function-binding-cosmosdb-v4
 
         :param arg_name: The name of the variable that represents
         :class:`DocumentList` input object in function code

--- a/azure/functions/decorators/function_app.py
+++ b/azure/functions/decorators/function_app.py
@@ -742,12 +742,14 @@ class TriggerApi(DecoratorApi, ABC):
                                  Union[DataType, str]] = None,
                              **kwargs: Any) -> \
             Callable[..., Any]:
-        """The cosmos_db_trigger decorator adds :class:`CosmosDBTrigger`
+        """The cosmos_db_trigger_v3 decorator adds :class:`CosmosDBTrigger`
         to the :class:`FunctionBuilder` object
         for building :class:`Function` object used in worker function
-        indexing model. This is equivalent to defining CosmosDBTrigger
-        in the function.json which enables function to be triggered when
-        CosmosDB data is changed.
+        indexing model. This decorator will work only with extension bundle 2.x
+        or 3.x. For additional details, please refer
+        https://github.com/Azure/azure-functions-python-worker/issues/1222.
+        This is equivalent to defining CosmosDBTrigger in the function.json
+         which enables function to be triggered when CosmosDB data is changed.
         All optional fields will be given default value by function host when
         they are parsed by function host.
 
@@ -867,9 +869,11 @@ class TriggerApi(DecoratorApi, ABC):
         """The cosmos_db_trigger decorator adds :class:`CosmosDBTrigger`
         to the :class:`FunctionBuilder` object
         for building :class:`Function` object used in worker function
-        indexing model. This is equivalent to defining CosmosDBTrigger
-        in the function.json which enables function to be triggered when
-        CosmosDB data is changed.
+        indexing model. This decorator will work only with extension bundle 4.x
+        and above. For additional details, please refer
+        https://github.com/Azure/azure-functions-python-worker/issues/1222.
+        This is equivalent to defining CosmosDBTrigger in the function.json
+        which enables function to be triggered when CosmosDB data is changed.
         All optional fields will be given default value by function host when
         they are parsed by function host.
 
@@ -1318,10 +1322,13 @@ class BindingApi(DecoratorApi, ABC):
                                 Union[DataType, str]] = None,
                             **kwargs) \
             -> Callable[..., Any]:
-        """The cosmos_db_output decorator adds
+        """The cosmos_db_output_v3 decorator adds
         :class:`CosmosDBOutput` to the :class:`FunctionBuilder` object
         for building :class:`Function` object used in worker function
-        indexing model. This is equivalent to defining CosmosDBOutput
+        indexing model. This decorator will work only with extension bundle 2.x
+        or 3.x. For additional details, please refer
+        https://github.com/Azure/azure-functions-python-worker/issues/1222.
+         This is equivalent to defining CosmosDBOutput
         in the function.json which enables function to write to the CosmosDB.
         All optional fields will be given default value by function host when
         they are parsed by function host.
@@ -1394,7 +1401,10 @@ class BindingApi(DecoratorApi, ABC):
         """The cosmos_db_output decorator adds
         :class:`CosmosDBOutput` to the :class:`FunctionBuilder` object
         for building :class:`Function` object used in worker function
-        indexing model. This is equivalent to defining CosmosDBOutput
+        indexing model. This decorator will work only with extension bundle 4.x
+        and above. For additional details, please refer
+        https://github.com/Azure/azure-functions-python-worker/issues/1222.
+        This is equivalent to defining CosmosDBOutput
         in the function.json which enables function to write to the CosmosDB.
         All optional fields will be given default value by function host when
         they are parsed by function host.
@@ -1461,10 +1471,13 @@ class BindingApi(DecoratorApi, ABC):
                                Union[DataType, str]] = None,
                            **kwargs) \
             -> Callable[..., Any]:
-        """The cosmos_db_input decorator adds
+        """The cosmos_db_input_v3 decorator adds
         :class:`CosmosDBInput` to the :class:`FunctionBuilder` object
         for building :class:`Function` object used in worker function
-        indexing model. This is equivalent to defining CosmosDBInput
+        indexing model. This decorator will work only with extension bundle 2.x
+        or 3.x. For additional details, please refer
+        https://github.com/Azure/azure-functions-python-worker/issues/1222.
+        This is equivalent to defining CosmosDBInput
         in the function.json which enables function to read from CosmosDB.
         All optional fields will be given default value by function host when
         they are parsed by function host.
@@ -1528,8 +1541,11 @@ class BindingApi(DecoratorApi, ABC):
         """The cosmos_db_input decorator adds
         :class:`CosmosDBInput` to the :class:`FunctionBuilder` object
         for building :class:`Function` object used in worker function
-        indexing model. This is equivalent to defining CosmosDBInput
-        in the function.json which enables function to read from CosmosDB.
+        indexing model. This decorator will work only with extension bundle 4.x
+        and above. For additional details, please refer
+        https://github.com/Azure/azure-functions-python-worker/issues/1222.
+        This is equivalent to defining CosmosDBInput in the function.json which
+         enables function to read from CosmosDB.
         All optional fields will be given default value by function host when
         they are parsed by function host.
 

--- a/tests/decorators/test_cosmosdb.py
+++ b/tests/decorators/test_cosmosdb.py
@@ -5,31 +5,32 @@ import unittest
 from azure.functions.decorators.constants import COSMOS_DB_TRIGGER, COSMOS_DB
 from azure.functions.decorators.core import BindingDirection, DataType
 from azure.functions.decorators.cosmosdb import CosmosDBTrigger, \
-    CosmosDBOutput, CosmosDBInput
+    CosmosDBOutput, CosmosDBInput, CosmosDBTriggerV3, CosmosDBOutputV3, \
+    CosmosDBInputV3
 
 
 class TestCosmosDB(unittest.TestCase):
-    def test_cosmos_db_trigger_valid_creation(self):
-        trigger = CosmosDBTrigger(name="req", database_name="dummy_db",
-                                  collection_name="dummy_collection",
-                                  connection_string_setting="dummy_str",
-                                  leases_collection_throughput=1,
-                                  checkpoint_interval=2,
-                                  checkpoint_document_count=3,
-                                  feed_poll_delay=4,
-                                  lease_renew_interval=5,
-                                  lease_acquire_interval=6,
-                                  lease_expiration_interval=7,
-                                  lease_collection_name='coll_name',
-                                  lease_collection_prefix='prefix',
-                                  lease_connection_string_setting='setting',
-                                  lease_database_name='db',
-                                  max_items_per_invocation=8,
-                                  start_from_beginning=False,
-                                  create_lease_collection_if_not_exists=False,
-                                  preferred_locations="dummy_loc",
-                                  data_type=DataType.UNDEFINED,
-                                  dummy_field="dummy")
+    def test_cosmos_db_trigger_v3_valid_creation(self):
+        trigger = CosmosDBTriggerV3(name="req", database_name="dummy_db",
+                                    collection_name="dummy_collection",
+                                    connection_string_setting="dummy_str",
+                                    leases_collection_throughput=1,
+                                    checkpoint_interval=2,
+                                    checkpoint_document_count=3,
+                                    feed_poll_delay=4,
+                                    lease_renew_interval=5,
+                                    lease_acquire_interval=6,
+                                    lease_expiration_interval=7,
+                                    lease_collection_name='coll_name',
+                                    lease_collection_prefix='prefix',
+                                    lease_connection_string_setting='setting',
+                                    lease_database_name='db',
+                                    max_items_per_invocation=8,
+                                    start_from_beginning=False,
+                                    create_lease_collection_if_not_exists=False,  # NoQA
+                                    preferred_locations="dummy_loc",
+                                    data_type=DataType.UNDEFINED,
+                                    dummy_field="dummy")
 
         self.assertEqual(trigger.get_binding_name(), "cosmosDBTrigger")
         self.assertEqual(trigger.get_dict_repr(),
@@ -57,18 +58,18 @@ class TestCosmosDB(unittest.TestCase):
                           "startFromBeginning": False,
                           "type": COSMOS_DB_TRIGGER})
 
-    def test_cosmos_db_output_valid_creation(self):
-        output = CosmosDBOutput(name="req",
-                                database_name="dummy_db",
-                                collection_name="dummy_collection",
-                                connection_string_setting="dummy_str",
-                                create_if_not_exists=False,
-                                collection_throughput=1,
-                                use_multiple_write_locations=False,
-                                data_type=DataType.UNDEFINED,
-                                partition_key='key',
-                                preferred_locations='locs',
-                                dummy_field="dummy")
+    def test_cosmos_db_output_v3_valid_creation(self):
+        output = CosmosDBOutputV3(name="req",
+                                  database_name="dummy_db",
+                                  collection_name="dummy_collection",
+                                  connection_string_setting="dummy_str",
+                                  create_if_not_exists=False,
+                                  collection_throughput=1,
+                                  use_multiple_write_locations=False,
+                                  data_type=DataType.UNDEFINED,
+                                  partition_key='key',
+                                  preferred_locations='locs',
+                                  dummy_field="dummy")
 
         self.assertEqual(output.get_binding_name(), "cosmosDB")
         self.assertEqual(output.get_dict_repr(),
@@ -86,15 +87,15 @@ class TestCosmosDB(unittest.TestCase):
                           'type': COSMOS_DB,
                           'useMultipleWriteLocations': False})
 
-    def test_cosmos_db_input_valid_creation(self):
-        cosmosdb_input = CosmosDBInput(name="req", database_name="dummy_db",
-                                       collection_name="dummy_collection",
-                                       connection_string_setting="dummy_str",
-                                       id="dummy_id",
-                                       sql_query="dummy_query",
-                                       partition_key="dummy_partitions",
-                                       data_type=DataType.UNDEFINED,
-                                       dummy_field="dummy")
+    def test_cosmos_db_input_v3_valid_creation(self):
+        cosmosdb_input = CosmosDBInputV3(name="req", database_name="dummy_db",
+                                         collection_name="dummy_collection",
+                                         connection_string_setting="dummy_str",
+                                         id="dummy_id",
+                                         sql_query="dummy_query",
+                                         partition_key="dummy_partitions",
+                                         data_type=DataType.UNDEFINED,
+                                         dummy_field="dummy")
         self.assertEqual(cosmosdb_input.get_binding_name(), "cosmosDB")
         self.assertEqual(cosmosdb_input.get_dict_repr(),
                          {'collectionName': 'dummy_collection',
@@ -107,4 +108,104 @@ class TestCosmosDB(unittest.TestCase):
                           'name': 'req',
                           'partitionKey': 'dummy_partitions',
                           'sqlQuery': 'dummy_query',
+                          'type': COSMOS_DB})
+
+    def test_cosmos_db_trigger_valid_creation(self):
+        trigger = CosmosDBTrigger(name="req", database_name="dummy_db",
+                                  container_name="dummy_container",
+                                  connection="dummy_str",
+                                  leases_container_throughput=1,
+                                  feed_poll_delay=4,
+                                  lease_renew_interval=5,
+                                  lease_acquire_interval=6,
+                                  lease_expiration_interval=7,
+                                  lease_container_name='container_name',
+                                  lease_container_prefix='prefix',
+                                  lease_connection='setting',
+                                  lease_database_name='db',
+                                  max_items_per_invocation=8,
+                                  start_from_beginning=False,
+                                  start_from_time="2021-02-16T14:19:29Z",
+                                  create_lease_container_if_not_exists=False,
+                                  preferred_locations="dummy_loc",
+                                  data_type=DataType.UNDEFINED,
+                                  dummy_field="dummy")
+
+        self.assertEqual(trigger.get_binding_name(), "cosmosDBTrigger")
+        self.assertEqual(trigger.get_dict_repr(),
+                         {"containerName": "dummy_container",
+                          "connection": "dummy_str",
+                          "createLeaseContainerIfNotExists": False,
+                          "dataType": DataType.UNDEFINED,
+                          "databaseName": "dummy_db",
+                          "direction": BindingDirection.IN,
+                          'dummyField': 'dummy',
+                          "feedPollDelay": 4,
+                          "leaseAcquireInterval": 6,
+                          "leaseContainerName": 'container_name',
+                          "leaseContainerPrefix": 'prefix',
+                          "leaseConnection": 'setting',
+                          "leaseDatabaseName": 'db',
+                          "leaseExpirationInterval": 7,
+                          "leaseRenewInterval": 5,
+                          "leasesContainerThroughput": 1,
+                          "maxItemsPerInvocation": 8,
+                          "name": "req",
+                          "preferredLocations": "dummy_loc",
+                          "startFromBeginning": False,
+                          "startFromTime": "2021-02-16T14:19:29Z",
+                          "type": COSMOS_DB_TRIGGER})
+
+    def test_cosmos_db_output_valid_creation(self):
+        output = CosmosDBOutput(name="req",
+                                database_name="dummy_db",
+                                container_name="dummy_container",
+                                connection="dummy_str",
+                                create_if_not_exists=False,
+                                container_throughput=1,
+                                use_multiple_write_locations=False,
+                                data_type=DataType.UNDEFINED,
+                                partition_key='key',
+                                preferred_locations='locs',
+                                dummy_field="dummy")
+        self.assertEqual(output.get_binding_name(), "cosmosDB")
+        self.assertEqual(output.get_dict_repr(),
+                         {'containerName': 'dummy_container',
+                          'containerThroughput': 1,
+                          'connection': 'dummy_str',
+                          'createIfNotExists': False,
+                          'dataType': DataType.UNDEFINED,
+                          'databaseName': 'dummy_db',
+                          'direction': BindingDirection.OUT,
+                          'dummyField': 'dummy',
+                          'name': 'req',
+                          'partitionKey': 'key',
+                          'preferredLocations': 'locs',
+                          'type': COSMOS_DB,
+                          'useMultipleWriteLocations': False})
+
+    def test_cosmos_db_input_valid_creation(self):
+        cosmosdb_input = CosmosDBInput(name="req",
+                                       database_name="dummy_db",
+                                       container_name="dummy_container",
+                                       connection="dummy_str",
+                                       id="dummy_id",
+                                       sql_query="dummy_query",
+                                       partition_key="dummy_partitions",
+                                       preferred_locations="EastUS",
+                                       data_type=DataType.UNDEFINED,
+                                       dummy_field="dummy")
+        self.assertEqual(cosmosdb_input.get_binding_name(), "cosmosDB")
+        self.assertEqual(cosmosdb_input.get_dict_repr(),
+                         {'containerName': 'dummy_container',
+                          'connection': 'dummy_str',
+                          'dataType': DataType.UNDEFINED,
+                          'databaseName': 'dummy_db',
+                          'direction': BindingDirection.IN,
+                          'dummyField': 'dummy',
+                          'id': 'dummy_id',
+                          'name': 'req',
+                          'partitionKey': 'dummy_partitions',
+                          'sqlQuery': 'dummy_query',
+                          'preferredLocations': "EastUS",
                           'type': COSMOS_DB})

--- a/tests/decorators/test_decorators.py
+++ b/tests/decorators/test_decorators.py
@@ -764,10 +764,10 @@ class TestFunctionsApp(unittest.TestCase):
             ]
         })
 
-    def test_cosmosdb_full_args(self):
+    def test_cosmosdb_v3_full_args(self):
         app = self.func_app
 
-        @app.cosmos_db_trigger(
+        @app.cosmos_db_trigger_v3(
             arg_name="trigger",
             database_name="dummy_db",
             collection_name="dummy_collection",
@@ -789,26 +789,26 @@ class TestFunctionsApp(unittest.TestCase):
             preferred_locations="dummy_loc",
             data_type=DataType.STRING,
             dummy_field="dummy")
-        @app.cosmos_db_input(arg_name="in",
-                             database_name="dummy_in_db",
-                             collection_name="dummy_in_collection",
-                             connection_string_setting="dummy_str",
-                             id="dummy_id",
-                             sql_query="dummy_query",
-                             partition_key="dummy_partitions",
-                             data_type=DataType.STRING,
-                             dummy_field="dummy")
-        @app.cosmos_db_output(arg_name="out",
-                              database_name="dummy_out_db",
-                              collection_name="dummy_out_collection",
-                              connection_string_setting="dummy_str",
-                              create_if_not_exists=False,
-                              partition_key="dummy_part_key",
-                              collection_throughput=1,
-                              use_multiple_write_locations=False,
-                              preferred_locations="dummy_location",
-                              data_type=DataType.STRING,
-                              dummy_field="dummy")
+        @app.cosmos_db_input_v3(arg_name="in",
+                                database_name="dummy_in_db",
+                                collection_name="dummy_in_collection",
+                                connection_string_setting="dummy_str",
+                                id="dummy_id",
+                                sql_query="dummy_query",
+                                partition_key="dummy_partitions",
+                                data_type=DataType.STRING,
+                                dummy_field="dummy")
+        @app.cosmos_db_output_v3(arg_name="out",
+                                 database_name="dummy_out_db",
+                                 collection_name="dummy_out_collection",
+                                 connection_string_setting="dummy_str",
+                                 create_if_not_exists=False,
+                                 partition_key="dummy_part_key",
+                                 collection_throughput=1,
+                                 use_multiple_write_locations=False,
+                                 preferred_locations="dummy_location",
+                                 data_type=DataType.STRING,
+                                 dummy_field="dummy")
         def dummy():
             pass
 
@@ -882,20 +882,134 @@ class TestFunctionsApp(unittest.TestCase):
                                  ]
                                  })
 
-    def test_cosmosdb_default_args(self):
+    def test_cosmosdb_full_args(self):
         app = self.func_app
 
-        @app.cosmos_db_trigger(arg_name="trigger", database_name="dummy_db",
-                               collection_name="dummy_collection",
-                               connection_string_setting="dummy_str")
+        @app.cosmos_db_trigger(
+            arg_name="trigger",
+            database_name="dummy_db",
+            container_name="dummy_container",
+            connection="dummy_str",
+            lease_container_name="dummy_lease_container",
+            lease_connection="dummy_lease_conn_str",
+            lease_database_name="dummy_lease_db",
+            leases_container_throughput=1,
+            lease_container_prefix="dummy_lease_container_prefix",
+            feed_poll_delay=4,
+            lease_renew_interval=5,
+            lease_acquire_interval=6,
+            lease_expiration_interval=7,
+            max_items_per_invocation=8,
+            start_from_beginning=False,
+            start_from_time="2021-02-16T14:19:29Z",
+            create_lease_container_if_not_exists=False,
+            preferred_locations="dummy_loc",
+            data_type=DataType.STRING,
+            dummy_field="dummy")
         @app.cosmos_db_input(arg_name="in",
                              database_name="dummy_in_db",
-                             collection_name="dummy_in_collection",
-                             connection_string_setting="dummy_str")
+                             container_name="dummy_in_container",
+                             connection="dummy_str",
+                             id="dummy_id",
+                             sql_query="dummy_query",
+                             partition_key="dummy_partitions",
+                             data_type=DataType.STRING,
+                             dummy_field="dummy")
         @app.cosmos_db_output(arg_name="out",
                               database_name="dummy_out_db",
-                              collection_name="dummy_out_collection",
-                              connection_string_setting="dummy_str")
+                              container_name="dummy_out_container",
+                              connection="dummy_str",
+                              create_if_not_exists=False,
+                              partition_key="dummy_part_key",
+                              container_throughput=1,
+                              use_multiple_write_locations=False,
+                              preferred_locations="dummy_location",
+                              data_type=DataType.STRING,
+                              dummy_field="dummy")
+        def dummy():
+            pass
+
+        func = self._get_user_function(app)
+
+        assert_json(self, func, {"scriptFile": "function_app.py",
+                                 "bindings": [
+                                     {
+                                         "direction": BindingDirection.OUT,
+                                         'dummyField': 'dummy',
+                                         "dataType": DataType.STRING,
+                                         "type": COSMOS_DB,
+                                         "name": "out",
+                                         "databaseName": "dummy_out_db",
+                                         "containerName":
+                                             "dummy_out_container",
+                                         "connection": "dummy_str",
+                                         "createIfNotExists": False,
+                                         "containerThroughput": 1,
+                                         "useMultipleWriteLocations": False,
+                                         "preferredLocations":
+                                             "dummy_location",
+                                         "partitionKey": "dummy_part_key"
+                                     },
+                                     {
+                                         "direction": BindingDirection.IN,
+                                         'dummyField': 'dummy',
+                                         "dataType": DataType.STRING,
+                                         "type": COSMOS_DB,
+                                         "name": "in",
+                                         "databaseName": "dummy_in_db",
+                                         "containerName":
+                                             "dummy_in_container",
+                                         "connection": "dummy_str",
+                                         "id": "dummy_id",
+                                         "sqlQuery": "dummy_query",
+                                         "partitionKey": "dummy_partitions"
+                                     },
+                                     {
+                                         "direction": BindingDirection.IN,
+                                         'dummyField': 'dummy',
+                                         "dataType": DataType.STRING,
+                                         "type": COSMOS_DB_TRIGGER,
+                                         "name": "trigger",
+                                         "databaseName": "dummy_db",
+                                         "containerName": "dummy_container",
+                                         "connection": "dummy_str",
+                                         "leasesContainerThroughput": 1,
+                                         "feedPollDelay": 4,
+                                         "leaseRenewInterval": 5,
+                                         "leaseAcquireInterval": 6,
+                                         "leaseExpirationInterval": 7,
+                                         "maxItemsPerInvocation": 8,
+                                         "startFromBeginning": False,
+                                         "startFromTime":
+                                             "2021-02-16T14:19:29Z",
+                                         "createLeaseContainerIfNotExists":
+                                             False,
+                                         "preferredLocations": "dummy_loc",
+                                         "leaseContainerName":
+                                             "dummy_lease_container",
+                                         "leaseConnection":
+                                             "dummy_lease_conn_str",
+                                         "leaseDatabaseName": "dummy_lease_db",
+                                         "leaseContainerPrefix":
+                                             "dummy_lease_container_prefix"
+                                     }
+                                 ]
+                                 })
+
+    def test_cosmosdb_v3_default_args(self):
+        app = self.func_app
+
+        @app.cosmos_db_trigger_v3(arg_name="trigger", database_name="dummy_db",
+                                  collection_name="dummy_collection",
+                                  connection_string_setting="dummy_str")
+        @app.cosmos_db_input_v3(arg_name="in",
+                                database_name="dummy_in_db",
+                                collection_name="dummy_in_collection",
+                                connection_string_setting="dummy_str")
+        @app.cosmos_db_output_v3(arg_name="out",
+                                 database_name="dummy_out_db",
+                                 collection_name="dummy_out_collection",
+                                 connection_string_setting="dummy_str")
         def dummy():
             pass
 
@@ -932,13 +1046,63 @@ class TestFunctionsApp(unittest.TestCase):
                                  ]
                                  })
 
-    def test_cosmosdb_trigger(self):
+    def test_cosmosdb_default_args(self):
         app = self.func_app
 
-        @app.cosmos_db_trigger(arg_name="trigger",
-                               database_name="dummy_db",
-                               collection_name="dummy_collection",
-                               connection_string_setting="dummy_str")
+        @app.cosmos_db_trigger(arg_name="trigger", database_name="dummy_db",
+                               container_name="dummy_container",
+                               connection="dummy_str")
+        @app.cosmos_db_input(arg_name="in",
+                             database_name="dummy_in_db",
+                             container_name="dummy_in_container",
+                             connection="dummy_str")
+        @app.cosmos_db_output(arg_name="out",
+                              database_name="dummy_out_db",
+                              container_name="dummy_out_container",
+                              connection="dummy_str")
+        def dummy():
+            pass
+
+        func = self._get_user_function(app)
+
+        assert_json(self, func, {"scriptFile": "function_app.py",
+                                 "bindings": [
+                                     {
+                                         "direction": BindingDirection.OUT,
+                                         "type": COSMOS_DB,
+                                         "name": "out",
+                                         "databaseName": "dummy_out_db",
+                                         "containerName":
+                                             "dummy_out_container",
+                                         "connection": "dummy_str"
+                                     },
+                                     {
+                                         "direction": BindingDirection.IN,
+                                         "type": COSMOS_DB,
+                                         "name": "in",
+                                         "databaseName": "dummy_in_db",
+                                         "containerName":
+                                             "dummy_in_container",
+                                         "connection": "dummy_str"
+                                     },
+                                     {
+                                         "direction": BindingDirection.IN,
+                                         "type": COSMOS_DB_TRIGGER,
+                                         "name": "trigger",
+                                         "databaseName": "dummy_db",
+                                         "containerName": "dummy_container",
+                                         "connection": "dummy_str"
+                                     }
+                                 ]
+                                 })
+
+    def test_cosmosdb_v3_trigger(self):
+        app = self.func_app
+
+        @app.cosmos_db_trigger_v3(arg_name="trigger",
+                                  database_name="dummy_db",
+                                  collection_name="dummy_collection",
+                                  connection_string_setting="dummy_str")
         def dummy():
             pass
 
@@ -956,13 +1120,37 @@ class TestFunctionsApp(unittest.TestCase):
             "connectionStringSetting": "dummy_str"
         })
 
+    def test_cosmosdb_trigger(self):
+        app = self.func_app
+
+        @app.cosmos_db_trigger(arg_name="trigger",
+                               database_name="dummy_db",
+                               container_name="dummy_container",
+                               connection="dummy_str")
+        def dummy():
+            pass
+
+        func = self._get_user_function(app)
+
+        self.assertEqual(len(func.get_bindings()), 1)
+
+        output = func.get_bindings()[0]
+        self.assertEqual(output.get_dict_repr(), {
+            "direction": BindingDirection.IN,
+            "type": COSMOS_DB_TRIGGER,
+            "name": "trigger",
+            "databaseName": "dummy_db",
+            "containerName": "dummy_container",
+            "connection": "dummy_str"
+        })
+
     def test_not_http_function(self):
         app = self.func_app
 
         @app.cosmos_db_trigger(arg_name="trigger",
                                database_name="dummy_db",
-                               collection_name="dummy_collection",
-                               connection_string_setting="dummy_str")
+                               container_name="dummy_container",
+                               connection="dummy_str")
         def dummy():
             pass
 
@@ -971,17 +1159,17 @@ class TestFunctionsApp(unittest.TestCase):
 
         self.assertFalse(funcs[0].is_http_function())
 
-    def test_cosmosdb_input_binding(self):
+    def test_cosmosdb_v3_input_binding(self):
         app = self.func_app
 
-        @app.cosmos_db_trigger(arg_name="trigger",
-                               database_name="dummy_db",
-                               collection_name="dummy_collection",
-                               connection_string_setting="dummy_str")
-        @app.cosmos_db_input(arg_name="in",
-                             database_name="dummy_in_db",
-                             collection_name="dummy_in_collection",
-                             connection_string_setting="dummy_str")
+        @app.cosmos_db_trigger_v3(arg_name="trigger",
+                                  database_name="dummy_db",
+                                  collection_name="dummy_collection",
+                                  connection_string_setting="dummy_str")
+        @app.cosmos_db_input_v3(arg_name="in",
+                                database_name="dummy_in_db",
+                                collection_name="dummy_in_collection",
+                                connection_string_setting="dummy_str")
         def dummy():
             pass
 
@@ -1000,17 +1188,46 @@ class TestFunctionsApp(unittest.TestCase):
             "connectionStringSetting": "dummy_str"
         })
 
-    def test_cosmosdb_output_binding(self):
+    def test_cosmosdb_input_binding(self):
         app = self.func_app
 
         @app.cosmos_db_trigger(arg_name="trigger",
                                database_name="dummy_db",
-                               collection_name="dummy_collection",
-                               connection_string_setting="dummy_str")
-        @app.cosmos_db_output(arg_name="out",
-                              database_name="dummy_out_db",
-                              collection_name="dummy_out_collection",
-                              connection_string_setting="dummy_str")
+                               container_name="dummy_container",
+                               connection="dummy_str")
+        @app.cosmos_db_input(arg_name="in",
+                             database_name="dummy_in_db",
+                             container_name="dummy_in_container",
+                             connection="dummy_str")
+        def dummy():
+            pass
+
+        func = self._get_user_function(app)
+
+        self.assertEqual(len(func.get_bindings()), 2)
+
+        output = func.get_bindings()[0]
+        self.assertEqual(output.get_dict_repr(), {
+            "direction": BindingDirection.IN,
+            "type": COSMOS_DB,
+            "name": "in",
+            "databaseName": "dummy_in_db",
+            "containerName":
+                "dummy_in_container",
+            "connection": "dummy_str"
+        })
+
+    def test_cosmosdb_v3_output_binding(self):
+        app = self.func_app
+
+        @app.cosmos_db_trigger_v3(arg_name="trigger",
+                                  database_name="dummy_db",
+                                  collection_name="dummy_collection",
+                                  connection_string_setting="dummy_str")
+        @app.cosmos_db_output_v3(arg_name="out",
+                                 database_name="dummy_out_db",
+                                 collection_name="dummy_out_collection",
+                                 connection_string_setting="dummy_str")
         def dummy():
             pass
 
@@ -1027,6 +1244,35 @@ class TestFunctionsApp(unittest.TestCase):
             "collectionName":
                 "dummy_out_collection",
             "connectionStringSetting": "dummy_str"
+        })
+
+    def test_cosmosdb_output_binding(self):
+        app = self.func_app
+
+        @app.cosmos_db_trigger(arg_name="trigger",
+                               database_name="dummy_db",
+                               container_name="dummy_container",
+                               connection="dummy_str")
+        @app.cosmos_db_output(arg_name="out",
+                              database_name="dummy_out_db",
+                              container_name="dummy_out_container",
+                              connection="dummy_str")
+        def dummy():
+            pass
+
+        func = self._get_user_function(app)
+
+        self.assertEqual(len(func.get_bindings()), 2)
+
+        output = func.get_bindings()[0]
+        self.assertEqual(output.get_dict_repr(), {
+            "direction": BindingDirection.OUT,
+            "type": COSMOS_DB,
+            "name": "out",
+            "databaseName": "dummy_out_db",
+            "containerName":
+                "dummy_out_container",
+            "connection": "dummy_str"
         })
 
     def test_multiple_triggers(self):
@@ -1069,8 +1315,8 @@ class TestFunctionsApp(unittest.TestCase):
         @app.cosmos_db_input(
             arg_name="in1",
             database_name="dummy_in_db",
-            collection_name="dummy_in_collection",
-            connection_string_setting="dummy_str",
+            container_name="dummy_in_container",
+            connection="dummy_str",
             id="dummy_id",
             sql_query="dummy_query",
             partition_key="dummy_partitions",
@@ -1078,8 +1324,8 @@ class TestFunctionsApp(unittest.TestCase):
         @app.cosmos_db_input(
             arg_name="in2",
             database_name="dummy_in_db",
-            collection_name="dummy_in_collection",
-            connection_string_setting="dummy_str",
+            container_name="dummy_in_container",
+            connection="dummy_str",
             id="dummy_id",
             sql_query="dummy_query",
             partition_key="dummy_partitions",
@@ -1117,10 +1363,9 @@ class TestFunctionsApp(unittest.TestCase):
                                          "type": COSMOS_DB,
                                          "name": "in2",
                                          "databaseName": "dummy_in_db",
-                                         "collectionName":
-                                             "dummy_in_collection",
-                                         "connectionStringSetting":
-                                             "dummy_str",
+                                         "containerName":
+                                             "dummy_in_container",
+                                         "connection": "dummy_str",
                                          "id": "dummy_id",
                                          "sqlQuery": "dummy_query",
                                          "partitionKey": "dummy_partitions"
@@ -1131,10 +1376,9 @@ class TestFunctionsApp(unittest.TestCase):
                                          "type": COSMOS_DB,
                                          "name": "in1",
                                          "databaseName": "dummy_in_db",
-                                         "collectionName":
-                                             "dummy_in_collection",
-                                         "connectionStringSetting":
-                                             "dummy_str",
+                                         "containerName":
+                                             "dummy_in_container",
+                                         "connection": "dummy_str",
                                          "id": "dummy_id",
                                          "sqlQuery": "dummy_query",
                                          "partitionKey": "dummy_partitions"


### PR DESCRIPTION
Added support for cosmos db v4 extension for the new programming model.

New decorators for cosmosdb:

Extension 2.x and 3.x 

- cosmos_db_trigger_v3
- cosmos_db_input_v3
- cosmos_db_output_v3

Extension 4.x and above

- cosmos_db_trigger 
- cosmos_db_input
- cosmos_db_output

The new v4 cosmos db extension installation can be found [here](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2?tabs=in-process%2Cextensionv4&pivots=programming-language-python#install-bundle)

The latest support configurations for the new programming model can be found [here](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2-input?tabs=python-v2%2Cin-process%2Cextensionv4&pivots=programming-language-python#configuration)