### PR TITLE
preserve pystein function app metadata key order

### DIFF
--- a/azure/functions/decorators/core.py
+++ b/azure/functions/decorators/core.py
@@ -115,7 +115,8 @@ class Binding(ABC):
 
         :return: Dictionary representation of the binding.
         """
-        for p in getattr(self, 'init_params', []):
+        params = list(dict.fromkeys(getattr(self, 'init_params', [])))
+        for p in params:
             if p not in Binding.EXCLUDED_INIT_PARAMS:
                 self._dict[to_camel_case(p)] = getattr(self, p, None)
 

--- a/azure/functions/decorators/function_app.py
+++ b/azure/functions/decorators/function_app.py
@@ -214,11 +214,11 @@ class FunctionBuilder(object):
         # http trigger
         if Trigger.is_supported_trigger_type(trigger, HttpTrigger):
             if getattr(trigger, 'route', None) is None:
-                getattr(trigger, 'init_params').add('route')
+                getattr(trigger, 'init_params').append('route')
                 setattr(trigger, 'route', function_name)
             if getattr(trigger, 'auth_level',
                        None) is None and auth_level is not None:
-                getattr(trigger, 'init_params').add('auth_level')
+                getattr(trigger, 'init_params').append('auth_level')
                 setattr(trigger, 'auth_level',
                         parse_singular_param_to_enum(auth_level, AuthLevel))
             self._function._is_http_function = True

--- a/azure/functions/decorators/utils.py
+++ b/azure/functions/decorators/utils.py
@@ -56,8 +56,8 @@ class BuildDictMeta(type):
 
             self = args[0]
 
-            init_params = set(inspect.signature(func).parameters.keys())
-            init_params.update(kwargs.keys())
+            init_params = list(inspect.signature(func).parameters.keys())
+            init_params.extend(list(kwargs.keys()))
             for key in kwargs.keys():
                 if not hasattr(self, key):
                     setattr(self, key, kwargs[key])


### PR DESCRIPTION
Fix for a rising incident that function app restarted as synctrigger calls fail due to inconsistent hash values every time function host calls /admin/synctriggers to get worker function app metadata. 