### PR TITLE
Optional source param for blob trigger

### DIFF
--- a/azure/functions/decorators/blob.py
+++ b/azure/functions/decorators/blob.py
@@ -12,7 +12,7 @@ class BlobTrigger(Trigger):
                  name: str,
                  path: str,
                  connection: str,
-                 source: BlobSource,
+                 source: Optional[BlobSource] = None,
                  data_type: Optional[DataType] = None,
                  **kwargs):
         self.path = path

--- a/azure/functions/decorators/function_app.py
+++ b/azure/functions/decorators/function_app.py
@@ -1114,8 +1114,8 @@ class TriggerApi(DecoratorApi, ABC):
                      arg_name: str,
                      path: str,
                      connection: str,
-                     source: BlobSource =
-                     BlobSource.LOGS_AND_CONTAINER_SCAN,
+                     source: Optional[BlobSource] =
+                     None,
                      data_type: Optional[DataType] = None,
                      **kwargs) -> Callable[..., Any]:
         """

--- a/docs/ProgModelSpec.pyi
+++ b/docs/ProgModelSpec.pyi
@@ -495,7 +495,7 @@ class TriggerApi(DecoratorApi, ABC):
                      arg_name: str,
                      path: str,
                      connection: str,
-                     source: BlobSource = BlobSource.LOGS_AND_CONTAINER_SCAN,
+                     source: Optional[BlobSource] = None,
                      data_type: Optional[DataType] = None,
                      **kwargs) -> Callable:
         """

--- a/tests/decorators/test_blob.py
+++ b/tests/decorators/test_blob.py
@@ -8,6 +8,44 @@ from azure.functions.decorators.core import BindingDirection, BlobSource, \
 
 
 class TestBlob(unittest.TestCase):
+    def test_blob_trigger_creation_with_no_source(self):
+        trigger = BlobTrigger(name="req",
+                              path="dummy_path",
+                              connection="dummy_connection",
+                              data_type=DataType.UNDEFINED,
+                              dummy_field="dummy")
+
+        self.assertEqual(trigger.get_binding_name(), "blobTrigger")
+        self.assertEqual(trigger.get_dict_repr(), {
+            "type": "blobTrigger",
+            "direction": BindingDirection.IN,
+            'dummyField': 'dummy',
+            "name": "req",
+            "dataType": DataType.UNDEFINED,
+            "path": "dummy_path",
+            "connection": "dummy_connection"
+        })
+
+    def test_blob_trigger_creation_with_default_specified_source(self):
+        trigger = BlobTrigger(name="req",
+                              path="dummy_path",
+                              connection="dummy_connection",
+                              source=BlobSource.LOGS_AND_CONTAINER_SCAN,
+                              data_type=DataType.UNDEFINED,
+                              dummy_field="dummy")
+
+        self.assertEqual(trigger.get_binding_name(), "blobTrigger")
+        self.assertEqual(trigger.get_dict_repr(), {
+            "type": "blobTrigger",
+            "direction": BindingDirection.IN,
+            'dummyField': 'dummy',
+            "name": "req",
+            "dataType": DataType.UNDEFINED,
+            "path": "dummy_path",
+            'source': BlobSource.LOGS_AND_CONTAINER_SCAN,
+            "connection": "dummy_connection"
+        })
+
     def test_blob_trigger_creation_with_source_as_string(self):
         trigger = BlobTrigger(name="req",
                               path="dummy_path",

--- a/tests/decorators/test_decorators.py
+++ b/tests/decorators/test_decorators.py
@@ -1662,7 +1662,6 @@ class TestFunctionsApp(unittest.TestCase):
             "type": BLOB_TRIGGER,
             "name": "req",
             "path": "dummy_path",
-            "source": BlobSource.LOGS_AND_CONTAINER_SCAN,
             "connection": "dummy_conn"
         })
 

--- a/tests/decorators/test_decorators.py
+++ b/tests/decorators/test_decorators.py
@@ -1569,8 +1569,6 @@ class TestFunctionsApp(unittest.TestCase):
                                          "type": BLOB_TRIGGER,
                                          "name": "req",
                                          "path": "dummy_path",
-                                         "source":
-                                         BlobSource.LOGS_AND_CONTAINER_SCAN,
                                          "connection": "dummy_conn"
                                      }]})
 
@@ -1595,7 +1593,6 @@ class TestFunctionsApp(unittest.TestCase):
             "type": BLOB_TRIGGER,
             "name": "req",
             "path": "dummy_path",
-            "source": BlobSource.LOGS_AND_CONTAINER_SCAN,
             "connection": "dummy_conn"
         })
 


### PR DESCRIPTION
Previously, the source param was required and set to a default value of `BlobSource.LOGS_AND_CONTAINER_SCAN`. This caused an error when indexing the blob trigger function saying: 
```Could not convert 'LOGS_AND_CONTAINER_SCAN' to BlobTriggerSource. Error converting value "LOGS_AND_CONTAINER_SCAN" to type 'Microsoft.Azure.WebJobs.BlobTriggerSource'. Path 'source', line 1, position 184. Requested value 'LOGS_AND_CONTAINER_SCAN' was not found.```

This fix addresses that issue.