### PR TITLE
Added eventgrid connection property

### DIFF
--- a/azure/functions/decorators/eventgrid.py
+++ b/azure/functions/decorators/eventgrid.py
@@ -27,10 +27,23 @@ class EventGridOutput(OutputBinding):
 
     def __init__(self,
                  name: str,
-                 topic_endpoint_uri: str,
-                 topic_key_setting: str,
+                 topic_endpoint_uri: Optional[str] = None,
+                 topic_key_setting: Optional[str] = None,
+                 connection: Optional[str] = None,
                  data_type: Optional[DataType] = None,
                  **kwargs):
+        if (connection is not None and (
+                topic_endpoint_uri is not None
+                or topic_key_setting is not None)) or \
+                (connection is None and (
+                topic_endpoint_uri is None
+                or topic_key_setting is None)):
+            raise ValueError(
+                "Specify either the 'Connection' property or both "
+                "'TopicKeySetting' and 'TopicEndpointUri' properties,"
+                " but not both.")
+
         self.topic_endpoint_uri = topic_endpoint_uri
         self.topic_key_setting = topic_key_setting
+        self.connection = connection
         super().__init__(name=name, data_type=data_type)

--- a/azure/functions/decorators/function_app.py
+++ b/azure/functions/decorators/function_app.py
@@ -2138,8 +2138,9 @@ class BindingApi(DecoratorApi, ABC):
 
     def event_grid_output(self,
                           arg_name: str,
-                          topic_endpoint_uri: str,
-                          topic_key_setting: str,
+                          topic_endpoint_uri: Optional[str] = None,
+                          topic_key_setting: Optional[str] = None,
+                          connection: Optional[str] = None,
                           data_type: Optional[
                               Union[DataType, str]] = None,
                           **kwargs) -> Callable[..., Any]:
@@ -2164,6 +2165,8 @@ class BindingApi(DecoratorApi, ABC):
         contains the URI for the custom topic.
         :param topic_key_setting: The name of an app setting that
         contains an access key for the custom topic.
+        :param connection: The value of the common prefix for the setting that
+        contains the topic endpoint URI.
         :return: Decorator function.
         """
 
@@ -2175,6 +2178,7 @@ class BindingApi(DecoratorApi, ABC):
                         name=arg_name,
                         topic_endpoint_uri=topic_endpoint_uri,
                         topic_key_setting=topic_key_setting,
+                        connection=connection,
                         data_type=parse_singular_param_to_enum(data_type,
                                                                DataType),
                         **kwargs))

--- a/tests/decorators/test_eventgrid.py
+++ b/tests/decorators/test_eventgrid.py
@@ -27,17 +27,46 @@ class TestEventGrid(unittest.TestCase):
         output = EventGridOutput(name="res",
                                  topic_endpoint_uri="dummy_topic_endpoint_uri",
                                  topic_key_setting="dummy_topic_key_setting",
-                                 connection="dummy_connection",
                                  data_type=DataType.UNDEFINED,
                                  dummy_field="dummy")
 
         self.assertEqual(output.get_binding_name(), "eventGrid")
         self.assertEqual(output.get_dict_repr(),
-                         {'connection': 'dummy_connection',
-                          'dataType': DataType.UNDEFINED,
-                          'direction': BindingDirection.OUT,
-                          'dummyField': 'dummy',
-                          'topicEndpointUri': 'dummy_topic_endpoint_uri',
-                          'topicKeySetting': 'dummy_topic_key_setting',
-                          'name': 'res',
-                          'type': EVENT_GRID})
+                         {'dataType': DataType.UNDEFINED,
+                             'direction': BindingDirection.OUT,
+                             'dummyField': 'dummy',
+                             'topicEndpointUri': 'dummy_topic_endpoint_uri',
+                             'topicKeySetting': 'dummy_topic_key_setting',
+                             'name': 'res',
+                             'type': EVENT_GRID})
+
+    def test_event_grid_output_valid_creation_with_connection(self):
+        output = EventGridOutput(name="res",
+                                 connection="dummy_connection",
+                                 data_type=DataType.UNDEFINED,
+                                 dummy_field="dummy")
+
+        self.assertEqual(output.connection, "dummy_connection")
+        self.assertIsNone(output.topic_endpoint_uri)
+        self.assertIsNone(output.topic_key_setting)
+
+    def test_event_grid_output_invalid_creation_with_both(self):
+        with self.assertRaises(ValueError) as context:
+            EventGridOutput(name="res",
+                            connection="dummy_connection",
+                            topic_endpoint_uri="dummy_topic_endpoint_uri",
+                            topic_key_setting="dummy_topic_key_setting")
+
+        self.assertTrue("Specify either the 'Connection' property or both "
+                        "'TopicKeySetting' and 'TopicEndpointUri' properties, "
+                        "but not both." in str(context.exception))
+
+    def test_event_grid_output_invalid_creation_with_none(self):
+        with self.assertRaises(ValueError) as context:
+            EventGridOutput(name="res",
+                            data_type=DataType.UNDEFINED,
+                            dummy_field="dummy")
+
+        self.assertTrue("Specify either the 'Connection' property or both "
+                        "'TopicKeySetting' and 'TopicEndpointUri' properties,"
+                        " but not both." in str(context.exception))


### PR DESCRIPTION
Added connection property to the eventgrid trigger.

Connection property is needed to use MI with eventgrid.
Ref: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-output?tabs=python-v2%2Cisolated-process%2Cnodejs-v4%2Cextensionv3&pivots=programming-language-python#identity-based-authentication

Event grid output binding decorator will have a connection arg. 
Function app can now have `connection`  or  a combination of `TopicKeySetting` and `TopicEndpointUri` but not both.


```
@app.event_grid_output(
    arg_name="outputEvent",
    topic_endpoint_uri="AzureWebJobsEventGridTopicUri",
    topic_key_setting="AzureWebJobsEventGridConnectionKey")
```

OR 

```

@app.event_grid_output(
    arg_name="outputEvent",
    connection="AzureWebJobsEventGridTopicUri")
```


Fixes: https://github.com/Azure/azure-functions-python-worker/issues/1501