### PR TITLE
Changed builds to use linux image

### DIFF
--- a/eng/templates/official/jobs/build-artifacts.yml
+++ b/eng/templates/official/jobs/build-artifacts.yml
@@ -2,6 +2,11 @@ jobs:
   - job: "Build"
     displayName: 'Build Python SDK'
 
+    pool:
+      name: 1es-pool-azfunc
+      image: 1es-ubuntu-22.04
+      os: linux
+
     templateContext:
       outputParentDirectory: $(Build.ArtifactStagingDirectory)
       outputs:


### PR DESCRIPTION
Previously, builds were done using a windows image. This resulted in the following warning messages when doing the builds: 
`ValueError: underlying buffer has been detached`

Changing to use a linux image resolves this.


Error:
`
  File "D:\a\_work\1\s\setup.py", line 23, in <module>
    setup(
  File "C:\hostedtoolcache\windows\Python\3.11.9\x64\Lib\site-packages\setuptools\__init__.py", line 87, in setup
    return distutils.core.setup(**attrs)
  File "C:\hostedtoolcache\windows\Python\3.11.9\x64\Lib\site-packages\setuptools\_distutils\core.py", line 185, in setup
    return run_commands(dist)
  File "C:\hostedtoolcache\windows\Python\3.11.9\x64\Lib\site-packages\setuptools\_distutils\core.py", line 201, in run_commands
    dist.run_commands()
  File "C:\hostedtoolcache\windows\Python\3.11.9\x64\Lib\site-packages\setuptools\_distutils\dist.py", line 968, in run_commands
    self.run_command(cmd)
  File "C:\hostedtoolcache\windows\Python\3.11.9\x64\Lib\site-packages\setuptools\dist.py", line 1217, in run_command
    super().run_command(command)
  File "C:\hostedtoolcache\windows\Python\3.11.9\x64\Lib\site-packages\setuptools\_distutils\dist.py", line 987, in run_command
    cmd_obj.run()
  File "C:\hostedtoolcache\windows\Python\3.11.9\x64\Lib\site-packages\wheel\bdist_wheel.py", line 422, in run
    self.write_wheelfile(distinfo_dir)
  File "C:\hostedtoolcache\windows\Python\3.11.9\x64\Lib\site-packages\wheel\bdist_wheel.py", line 469, in write_wheelfile
    log.info(f"creating {wheelfile_path}")
Message: 'creating build\\bdist.win-amd64\\wheel\\azure_functions-1.20.0.dist-info\\WHEEL'
Arguments: ()`