### PR TITLE
chore: allow forked pr to run labeler pipeline

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-  pull_request:
+  pull_request_target:
     paths:
     - '**/__init__.py'
 jobs:


### PR DESCRIPTION
Currently prs from forked pr will not have write access to run this action. Ex. https://github.com/Azure/azure-functions-python-library/pull/243 Making changes to allow that https://github.com/actions/labeler?tab=readme-ov-file#permissions