### PR TITLE
fix: value resolution for BlobSource.EVENT_GRID

### DIFF
--- a/azure/functions/decorators/blob.py
+++ b/azure/functions/decorators/blob.py
@@ -17,7 +17,7 @@ class BlobTrigger(Trigger):
                  **kwargs):
         self.path = path
         self.connection = connection
-        self.source = source
+        self.source = source.value if source else None
         super().__init__(name=name, data_type=data_type)
 
     @staticmethod

--- a/tests/decorators/test_blob.py
+++ b/tests/decorators/test_blob.py
@@ -42,7 +42,7 @@ class TestBlob(unittest.TestCase):
             "name": "req",
             "dataType": DataType.UNDEFINED,
             "path": "dummy_path",
-            'source': BlobSource.LOGS_AND_CONTAINER_SCAN,
+            'source': 'LogsAndContainerScan',
             "connection": "dummy_connection"
         })
 
@@ -62,7 +62,7 @@ class TestBlob(unittest.TestCase):
             "name": "req",
             "dataType": DataType.UNDEFINED,
             "path": "dummy_path",
-            'source': BlobSource.EVENT_GRID,
+            'source': 'EventGrid',
             "connection": "dummy_connection"
         })
 
@@ -82,7 +82,7 @@ class TestBlob(unittest.TestCase):
             "name": "req",
             "dataType": DataType.UNDEFINED,
             "path": "dummy_path",
-            'source': BlobSource.EVENT_GRID,
+            'source': 'EventGrid',
             "connection": "dummy_connection"
         })
 

--- a/tests/decorators/test_decorators.py
+++ b/tests/decorators/test_decorators.py
@@ -1628,7 +1628,7 @@ class TestFunctionsApp(unittest.TestCase):
             "type": BLOB_TRIGGER,
             "name": "req",
             "path": "dummy_path",
-            "source": BlobSource.EVENT_GRID,
+            "source": 'EventGrid',
             "connection": "dummy_conn"
         })
 


### PR DESCRIPTION
**Change to be incorporated in 1.21.1.**

When defining a BlobTrigger using `BlobSource.EVENT_GRID`, the source value was not being resolved correctly, and the error below was being thrown. This is because the host was receiving `EVENT_GRID` as the source value, instead of the correct value `"EventGrid"`. This changes what source is set to in the `BlobTrigger` decorator. If source is defined, source is set to the `EVENT_GRID` value. If source is not defined, source is set to null and is ignored.

```
@app.blob_trigger(arg_name="myblob",
                  path="mycontainer",
                  data_type=func.DataType.STRING,
                  source = func.BlobSource.EVENT_GRID,
                  connection="AzureWebJobsStorage") 
```

```
The 'blob_trigger' function is in error: Unable to configure binding 'myblob' of type 'blobTrigger'. This may indicate invalid function.json properties. Could not convert 'EVENT_GRID' to BlobTriggerSource. Error converting value "EVENT_GRID" to type 'Microsoft.Azure.WebJobs.BlobTriggerSource'. Path 'source', line 1, position 165. Requested value 'EVENT_GRID' was not found.
```

Fixes: https://github.com/Azure/azure-functions-python-worker/issues/1582