### PR TITLE
fix: allow source to be string and enum

### DIFF
--- a/azure/functions/decorators/blob.py
+++ b/azure/functions/decorators/blob.py
@@ -17,7 +17,10 @@ class BlobTrigger(Trigger):
                  **kwargs):
         self.path = path
         self.connection = connection
-        self.source = source.value if source else None
+        if type(source) is BlobSource:
+            self.source = source.value if source else None
+        else:
+            self.source = source
         super().__init__(name=name, data_type=data_type)
 
     @staticmethod

--- a/azure/functions/decorators/blob.py
+++ b/azure/functions/decorators/blob.py
@@ -17,8 +17,8 @@ class BlobTrigger(Trigger):
                  **kwargs):
         self.path = path
         self.connection = connection
-        if type(source) is BlobSource:
-            self.source = source.value if source else None
+        if isinstance(source, BlobSource):
+            self.source = source.value
         else:
             self.source = source
         super().__init__(name=name, data_type=data_type)

--- a/azure/functions/decorators/blob.py
+++ b/azure/functions/decorators/blob.py
@@ -20,7 +20,7 @@ class BlobTrigger(Trigger):
         if isinstance(source, BlobSource):
             self.source = source.value
         else:
-            self.source = source
+            self.source = source  # type: ignore
         super().__init__(name=name, data_type=data_type)
 
     @staticmethod

--- a/tests/decorators/test_blob.py
+++ b/tests/decorators/test_blob.py
@@ -50,7 +50,7 @@ class TestBlob(unittest.TestCase):
         trigger = BlobTrigger(name="req",
                               path="dummy_path",
                               connection="dummy_connection",
-                              source=BlobSource.EVENT_GRID,
+                              source="EventGrid",
                               data_type=DataType.UNDEFINED,
                               dummy_field="dummy")
 


### PR DESCRIPTION
With the changes from https://github.com/Azure/azure-functions-python-library/pull/249, only `BlobSource` values were accepted. If the user put a string, indexing would fail.

This changes the `source` parameter to accept both `BlobSource` and string values.