### PR TITLE
fix: Adding mysql trigger binding to python

### DIFF
--- a/azure/functions/mysql.py
+++ b/azure/functions/mysql.py
@@ -76,3 +76,7 @@ class MySqlConverter(meta.InConverter, meta.OutConverter,
             type='json',
             value=json.dumps([dict(d) for d in data])
         )
+
+class MySqlTriggerConverter(MySqlConverter,
+                               binding='mysqlTrigger', trigger=True):
+    pass


### PR DESCRIPTION
Add mysqlTrigger binding type to python