### PR TITLE
build: library release fixes

### DIFF
--- a/eng/ci/library-release.yml
+++ b/eng/ci/library-release.yml
@@ -1,15 +1,21 @@
+pr: none
+
 resources:
   repositories:
     - repository: 1es
       type: git
       name: 1ESPipelineTemplates/1ESPipelineTemplates
       ref: refs/tags/release
+    - repository: eng
+      type: git
+      name: engineering
+      ref: refs/tags/release
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1es
   parameters:
     pool:
-      name: 1es-pool-azfunc-public
+      name: 1es-pool-azfunc
       image: 1es-windows-2022
       os: windows
     sdl:
@@ -17,8 +23,6 @@ extends:
          compiled:
            enabled: true # still only runs for default branch
          runSourceLanguagesInSourceAnalysis: true
-    settings:
-      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
 
     stages:
       - stage: Release

--- a/eng/ci/library-release.yml
+++ b/eng/ci/library-release.yml
@@ -18,11 +18,6 @@ extends:
       name: 1es-pool-azfunc
       image: 1es-windows-2022
       os: windows
-    sdl:
-      codeql:
-         compiled:
-           enabled: true # still only runs for default branch
-         runSourceLanguagesInSourceAnalysis: true
 
     stages:
       - stage: Release

--- a/eng/ci/library-release.yml
+++ b/eng/ci/library-release.yml
@@ -6,10 +6,6 @@ resources:
       type: git
       name: 1ESPipelineTemplates/1ESPipelineTemplates
       ref: refs/tags/release
-    - repository: eng
-      type: git
-      name: engineering
-      ref: refs/tags/release
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1es


### PR DESCRIPTION
Misc. release pipeline fixes:
- skipBuildTagsForGitHubPullRequests not needed because the pipeline will not run on forks
- remove CodeQL
- corrected pool