### PR TITLE
fix: OpenAI decorators: Optional aiConnectionName param added

### DIFF
--- a/azure/functions/decorators/function_app.py
+++ b/azure/functions/decorators/function_app.py
@@ -3217,6 +3217,7 @@ class BindingApi(DecoratorApi, ABC):
     def text_completion_input(self,
                               arg_name: str,
                               prompt: str,
+                              ai_connection_name: Optional[str] = "",
                               chat_model: Optional
                               [Union[str, OpenAIModels]]
                               = OpenAIModels.DefaultChatModel,
@@ -3243,6 +3244,14 @@ class BindingApi(DecoratorApi, ABC):
         :param arg_name: The name of binding parameter in the function code.
         :param prompt: The prompt to generate completions for, encoded as a
         string.
+        :param ai_connection_name: The name of the configuration section for
+        AI service connectivity settings. For Azure OpenAI: If specified, looks
+        for "Endpoint" and/or "Key" values in this configuration section. If
+        not specified or the section doesn't exist, falls back to environment
+        variables: AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_KEY. For
+        user-assigned managed identity authentication, this property is
+        required. For OpenAI service (non-Azure), set the OPENAI_API_KEY
+        environment variable.
         :param model: @deprecated. Use chat_model instead. The model parameter
         is unused and will be removed in future versions.
         :param chat_model: The deployment name or model name of OpenAI Chat
@@ -3277,6 +3286,7 @@ class BindingApi(DecoratorApi, ABC):
                     binding=TextCompletionInput(
                         name=arg_name,
                         prompt=prompt,
+                        ai_connection_name=ai_connection_name,
                         chat_model=chat_model,
                         temperature=temperature,
                         top_p=top_p,
@@ -3378,6 +3388,7 @@ class BindingApi(DecoratorApi, ABC):
     def assistant_post_input(self, arg_name: str,
                              id: str,
                              user_message: str,
+                             ai_connection_name: Optional[str] = "",
                              chat_model: Optional
                              [Union[str, OpenAIModels]]
                              = OpenAIModels.DefaultChatModel,
@@ -3399,6 +3410,14 @@ class BindingApi(DecoratorApi, ABC):
         :param id: The ID of the assistant to update.
         :param user_message: The user message that user has entered for
         assistant to respond to.
+        :param ai_connection_name: The name of the configuration section for
+        AI service connectivity settings. For Azure OpenAI: If specified, looks
+        for "Endpoint" and/or "Key" values in this configuration section. If
+        not specified or the section doesn't exist, falls back to environment
+        variables: AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_KEY. For
+        user-assigned managed identity authentication, this property is
+        required. For OpenAI service (non-Azure), set the OPENAI_API_KEY
+        environment variable.
         :param model: @deprecated. Use chat_model instead. The model parameter
         is unused and will be removed in future versions.
         :param chat_model: The deployment name or model name of OpenAI Chat
@@ -3439,6 +3458,7 @@ class BindingApi(DecoratorApi, ABC):
                         name=arg_name,
                         id=id,
                         user_message=user_message,
+                        ai_connection_name=ai_connection_name,
                         chat_model=chat_model,
                         chat_storage_connection_setting=chat_storage_connection_setting,       # noqa: E501
                         collection_name=collection_name,
@@ -3459,6 +3479,7 @@ class BindingApi(DecoratorApi, ABC):
                          arg_name: str,
                          input: str,
                          input_type: InputType,
+                         ai_connection_name: Optional[str] = "",
                          embeddings_model: Optional
                          [Union[str, OpenAIModels]]
                          = OpenAIModels.DefaultEmbeddingsModel,
@@ -3478,6 +3499,14 @@ class BindingApi(DecoratorApi, ABC):
         :param input: The input source containing the data to generate
         embeddings for.
         :param input_type: The type of the input.
+        :param ai_connection_name: The name of the configuration section for
+        AI service connectivity settings. For Azure OpenAI: If specified, looks
+        for "Endpoint" and/or "Key" values in this configuration section. If
+        not specified or the section doesn't exist, falls back to environment
+        variables: AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_KEY. For
+        user-assigned managed identity authentication, this property is
+        required. For OpenAI service (non-Azure), set the OPENAI_API_KEY
+        environment variable.
         :param model: @deprecated. Use embeddings_model instead. The model
         parameter is unused and will be removed in future versions.
         :param embeddings_model: The deployment name or model name for OpenAI
@@ -3502,6 +3531,7 @@ class BindingApi(DecoratorApi, ABC):
                         name=arg_name,
                         input=input,
                         input_type=input_type,
+                        ai_connection_name=ai_connection_name,
                         embeddings_model=embeddings_model,
                         max_chunk_length=max_chunk_length,
                         max_overlap=max_overlap,
@@ -3519,6 +3549,7 @@ class BindingApi(DecoratorApi, ABC):
                               search_connection_name: str,
                               collection: str,
                               query: Optional[str] = None,
+                              ai_connection_name: Optional[str] = "",
                               embeddings_model: Optional
                               [Union[str, OpenAIModels]]
                               = OpenAIModels.DefaultEmbeddingsModel,
@@ -3552,6 +3583,14 @@ class BindingApi(DecoratorApi, ABC):
         :param collection: The name of the collection or table to search or
         store.
         :param query: The semantic query text to use for searching.
+        :param ai_connection_name: The name of the configuration section for
+        AI service connectivity settings. For Azure OpenAI: If specified, looks
+        for "Endpoint" and/or "Key" values in this configuration section. If
+        not specified or the section doesn't exist, falls back to environment
+        variables: AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_KEY. For
+        user-assigned managed identity authentication, this property is
+        required. For OpenAI service (non-Azure), set the OPENAI_API_KEY
+        environment variable.
         :param embeddings_model: The deployment name or model name for OpenAI
         Embeddings. The default value is "text-embedding-ada-002".
         :param chat_model: The deployment name or model name of OpenAI Chat
@@ -3592,6 +3631,7 @@ class BindingApi(DecoratorApi, ABC):
                         search_connection_name=search_connection_name,
                         collection=collection,
                         query=query,
+                        ai_connection_name=ai_connection_name,
                         embeddings_model=embeddings_model,
                         chat_model=chat_model,
                         system_prompt=system_prompt,
@@ -3615,6 +3655,7 @@ class BindingApi(DecoratorApi, ABC):
                                 input_type: InputType,
                                 store_connection_name: str,
                                 collection: str,
+                                ai_connection_name: Optional[str] = "",
                                 embeddings_model: Optional
                                 [Union[str, OpenAIModels]]
                                 = OpenAIModels.DefaultEmbeddingsModel,
@@ -3640,6 +3681,14 @@ class BindingApi(DecoratorApi, ABC):
         :param store_connection_name: The name of an app setting or environment
         variable which contains a vectore store connection setting value
         :param collection: The collection or table to search.
+        :param ai_connection_name: The name of the configuration section for
+        AI service connectivity settings. For Azure OpenAI: If specified, looks
+        for "Endpoint" and/or "Key" values in this configuration section. If
+        not specified or the section doesn't exist, falls back to environment
+        variables: AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_KEY. For
+        user-assigned managed identity authentication, this property is
+        required. For OpenAI service (non-Azure), set the OPENAI_API_KEY
+        environment variable.
         :param model: @deprecated. Use embeddings_model instead. The model
         parameter is unused and will be removed in future versions.
         :param embeddings_model: The deployment name or model name for OpenAI
@@ -3666,6 +3715,7 @@ class BindingApi(DecoratorApi, ABC):
                         input_type=input_type,
                         store_connection_name=store_connection_name,
                         collection=collection,
+                        ai_connection_name=ai_connection_name,
                         embeddings_model=embeddings_model,
                         max_chunk_length=max_chunk_length,
                         max_overlap=max_overlap,

--- a/azure/functions/decorators/openai.py
+++ b/azure/functions/decorators/openai.py
@@ -51,6 +51,7 @@ class TextCompletionInput(InputBinding):
     def __init__(self,
                  name: str,
                  prompt: str,
+                 ai_connection_name: Optional[str] = "",
                  chat_model: Optional
                  [Union[str, OpenAIModels]]
                  = OpenAIModels.DefaultChatModel,
@@ -61,6 +62,7 @@ class TextCompletionInput(InputBinding):
                  data_type: Optional[DataType] = None,
                  **kwargs):
         self.prompt = prompt
+        self.ai_connection_name = ai_connection_name
         self.chat_model = chat_model
         self.temperature = temperature
         self.top_p = top_p
@@ -100,6 +102,7 @@ class EmbeddingsInput(InputBinding):
                  name: str,
                  input: str,
                  input_type: InputType,
+                 ai_connection_name: Optional[str] = "",
                  embeddings_model: Optional
                  [Union[str, OpenAIModels]]
                  = OpenAIModels.DefaultEmbeddingsModel,
@@ -110,6 +113,7 @@ class EmbeddingsInput(InputBinding):
         self.name = name
         self.input = input
         self.input_type = input_type
+        self.ai_connection_name = ai_connection_name
         self.embeddings_model = embeddings_model
         self.max_chunk_length = max_chunk_length
         self.max_overlap = max_overlap
@@ -144,6 +148,7 @@ class SemanticSearchInput(InputBinding):
                  search_connection_name: str,
                  collection: str,
                  query: Optional[str] = None,
+                 ai_connection_name: Optional[str] = "",
                  embeddings_model: Optional
                  [Union[str, OpenAIModels]]
                  = OpenAIModels.DefaultEmbeddingsModel,
@@ -162,6 +167,7 @@ class SemanticSearchInput(InputBinding):
         self.search_connection_name = search_connection_name
         self.collection = collection
         self.query = query
+        self.ai_connection_name = ai_connection_name
         self.embeddings_model = embeddings_model
         self.chat_model = chat_model
         self.system_prompt = system_prompt
@@ -182,6 +188,7 @@ class AssistantPostInput(InputBinding):
     def __init__(self, name: str,
                  id: str,
                  user_message: str,
+                 ai_connection_name: Optional[str] = "",
                  chat_model: Optional
                  [Union[str, OpenAIModels]]
                  = OpenAIModels.DefaultChatModel,
@@ -196,6 +203,7 @@ class AssistantPostInput(InputBinding):
         self.name = name
         self.id = id
         self.user_message = user_message
+        self.ai_connection_name = ai_connection_name
         self.chat_model = chat_model
         self.chat_storage_connection_setting = chat_storage_connection_setting
         self.collection_name = collection_name
@@ -218,6 +226,7 @@ class EmbeddingsStoreOutput(OutputBinding):
                  input_type: InputType,
                  store_connection_name: str,
                  collection: str,
+                 ai_connection_name: Optional[str] = "",
                  embeddings_model: Optional
                  [Union[str, OpenAIModels]]
                  = OpenAIModels.DefaultEmbeddingsModel,
@@ -230,6 +239,7 @@ class EmbeddingsStoreOutput(OutputBinding):
         self.input_type = input_type
         self.store_connection_name = store_connection_name
         self.collection = collection
+        self.ai_connection_name = ai_connection_name
         self.embeddings_model = embeddings_model
         self.max_chunk_length = max_chunk_length
         self.max_overlap = max_overlap

--- a/tests/decorators/test_openai.py
+++ b/tests/decorators/test_openai.py
@@ -50,6 +50,7 @@ class TestOpenAI(unittest.TestCase):
             is_reasoning_model=False,
             data_type=DataType.UNDEFINED,
             chat_model=OpenAIModels.DefaultChatModel,
+            ai_connection_name="test_connection",
             dummy_field="dummy",
         )
         self.assertEqual(input.get_binding_name(), "textCompletion")
@@ -66,6 +67,7 @@ class TestOpenAI(unittest.TestCase):
                 "direction": BindingDirection.IN,
                 "chatModel": OpenAIModels.DefaultChatModel,
                 "isReasoningModel": False,
+                "aiConnectionName": "test_connection",
             },
         )
 
@@ -78,6 +80,7 @@ class TestOpenAI(unittest.TestCase):
             is_reasoning_model=True,
             data_type=DataType.UNDEFINED,
             chat_model="gpt-4o",
+            ai_connection_name="test_connection",
             dummy_field="dummy",
         )
         self.assertEqual(input.get_binding_name(), "textCompletion")
@@ -94,6 +97,7 @@ class TestOpenAI(unittest.TestCase):
                 "direction": BindingDirection.IN,
                 "chatModel": "gpt-4o",
                 "isReasoningModel": True,
+                "aiConnectionName": "test_connection",
             },
         )
 
@@ -133,6 +137,7 @@ class TestOpenAI(unittest.TestCase):
             embeddings_model="test_model",
             max_overlap=1,
             max_chunk_length=1,
+            ai_connection_name="test_connection",
             dummy_field="dummy",
         )
         self.assertEqual(input.get_binding_name(), "embeddings")
@@ -148,6 +153,7 @@ class TestOpenAI(unittest.TestCase):
                 "maxOverlap": 1,
                 "maxChunkLength": 1,
                 "direction": BindingDirection.IN,
+                "aiConnectionName": "test_connection",
                 "dummyField": "dummy",
             },
         )
@@ -161,6 +167,7 @@ class TestOpenAI(unittest.TestCase):
             embeddings_model=OpenAIModels.DefaultEmbeddingsModel,
             max_overlap=1,
             max_chunk_length=1,
+            ai_connection_name="test_connection",
             dummy_field="dummy",
         )
         self.assertEqual(input.get_binding_name(), "embeddings")
@@ -176,6 +183,7 @@ class TestOpenAI(unittest.TestCase):
                 "maxOverlap": 1,
                 "maxChunkLength": 1,
                 "direction": BindingDirection.IN,
+                "aiConnectionName": "test_connection",
                 "dummyField": "dummy",
             },
         )
@@ -206,6 +214,7 @@ class TestOpenAI(unittest.TestCase):
             temperature="1",
             max_tokens="1",
             is_reasoning_model=False,
+            ai_connection_name="test_connection",
             data_type=DataType.UNDEFINED,
             dummy_field="dummy",
         )
@@ -222,6 +231,7 @@ class TestOpenAI(unittest.TestCase):
                 "temperature": "1",
                 "maxTokens": "1",
                 "isReasoningModel": False,
+                "aiConnectionName": "test_connection",
                 "dataType": DataType.UNDEFINED,
                 "direction": BindingDirection.IN,
                 "dummyField": "dummy",
@@ -240,6 +250,7 @@ class TestOpenAI(unittest.TestCase):
             temperature="1",
             max_tokens="1",
             is_reasoning_model=False,
+            ai_connection_name="test_connection",
             data_type=DataType.UNDEFINED,
             dummy_field="dummy",
         )
@@ -256,6 +267,7 @@ class TestOpenAI(unittest.TestCase):
                 "temperature": "1",
                 "maxTokens": "1",
                 "isReasoningModel": False,
+                "aiConnectionName": "test_connection",
                 "dataType": DataType.UNDEFINED,
                 "direction": BindingDirection.IN,
                 "dummyField": "dummy",
@@ -277,6 +289,7 @@ class TestOpenAI(unittest.TestCase):
             temperature="1",
             max_tokens="1",
             is_reasoning_model=False,
+            ai_connection_name="test_connection",
             dummy_field="dummy_field",
         )
         self.assertEqual(input.get_binding_name(), "semanticSearch")
@@ -297,6 +310,7 @@ class TestOpenAI(unittest.TestCase):
                 "temperature": "1",
                 "maxTokens": "1",
                 "isReasoningModel": False,
+                "aiConnectionName": "test_connection",
                 "query": "test_query",
             },
         )
@@ -315,6 +329,7 @@ class TestOpenAI(unittest.TestCase):
             temperature="1",
             max_tokens="1",
             is_reasoning_model=True,
+            ai_connection_name="test_connection",
             dummy_field="dummy_field",
         )
         self.assertEqual(input.get_binding_name(), "semanticSearch")
@@ -335,6 +350,7 @@ class TestOpenAI(unittest.TestCase):
                 "temperature": "1",
                 "maxTokens": "1",
                 "isReasoningModel": True,
+                "aiConnectionName": "test_connection",
                 "query": "test_query",
             },
         )
@@ -350,6 +366,7 @@ class TestOpenAI(unittest.TestCase):
             max_chunk_length=1,
             collection="test_collection",
             embeddings_model=OpenAIModels.DefaultEmbeddingsModel,  # noqa: E501
+            ai_connection_name="test_connection",
             dummy_field="dummy_field",
         )
         self.assertEqual(output.get_binding_name(), "embeddingsStore")
@@ -368,6 +385,7 @@ class TestOpenAI(unittest.TestCase):
                 "maxOverlap": 1,
                 "maxChunkLength": 1,
                 "type": "embeddingsStore",
+                "aiConnectionName": "test_connection",
             },
         )
 
@@ -382,6 +400,7 @@ class TestOpenAI(unittest.TestCase):
             max_chunk_length=1,
             collection="test_collection",
             embeddings_model="text-embedding-3-small",
+            ai_connection_name="test_connection",
             dummy_field="dummy_field",
         )
         self.assertEqual(output.get_binding_name(), "embeddingsStore")
@@ -400,5 +419,6 @@ class TestOpenAI(unittest.TestCase):
                 "maxOverlap": 1,
                 "maxChunkLength": 1,
                 "type": "embeddingsStore",
+                "aiConnectionName": "test_connection",
             },
         )


### PR DESCRIPTION
This pull request introduces support for specifying an `ai_connection_name` parameter across multiple methods and classes in the `azure/functions/decorators` module. This parameter allows users to configure AI service connectivity settings, providing flexibility for both Azure OpenAI and non-Azure OpenAI services. The changes also include updates to the corresponding test cases to validate the new functionality.

### Enhancements to AI Service Configuration:

* **Added `ai_connection_name` Parameter**:
  - Introduced the optional `ai_connection_name` parameter in several methods (`text_completion_input`, `assistant_post_input`, `embeddings_input`, `semantic_search_input`, and `embeddings_store_output`) within `azure/functions/decorators/function_app.py`. This parameter enables users to specify configuration settings for AI service connectivity, with fallback options to environment variables for both Azure OpenAI and non-Azure OpenAI services. [[1]](diffhunk://#diff-2bce725171c032a4585b48dbe4859cb1197d864a0f4a02fe8ed6b1cab87ae985R3220) [[2]](diffhunk://#diff-2bce725171c032a4585b48dbe4859cb1197d864a0f4a02fe8ed6b1cab87ae985R3391) [[3]](diffhunk://#diff-2bce725171c032a4585b48dbe4859cb1197d864a0f4a02fe8ed6b1cab87ae985R3482) [[4]](diffhunk://#diff-2bce725171c032a4585b48dbe4859cb1197d864a0f4a02fe8ed6b1cab87ae985R3552) [[5]](diffhunk://#diff-2bce725171c032a4585b48dbe4859cb1197d864a0f4a02fe8ed6b1cab87ae985R3658)
  - Updated the corresponding `__init__` methods in `azure/functions/decorators/openai.py` to include the `ai_connection_name` parameter, ensuring it is properly stored and utilized in various AI-related operations. [[1]](diffhunk://#diff-d1a2c69fe2dcd1138ede5b4396a8a4c7b1da9fa1dba32f19d62654ec24e49c61R54) [[2]](diffhunk://#diff-d1a2c69fe2dcd1138ede5b4396a8a4c7b1da9fa1dba32f19d62654ec24e49c61R105) [[3]](diffhunk://#diff-d1a2c69fe2dcd1138ede5b4396a8a4c7b1da9fa1dba32f19d62654ec24e49c61R151) [[4]](diffhunk://#diff-d1a2c69fe2dcd1138ede5b4396a8a4c7b1da9fa1dba32f19d62654ec24e49c61R191) [[5]](diffhunk://#diff-d1a2c69fe2dcd1138ede5b4396a8a4c7b1da9fa1dba32f19d62654ec24e49c61R229)

### Test Coverage Updates:

* **Enhanced Unit Tests**:
  - Updated test cases in `tests/decorators/test_openai.py` to include scenarios validating the `ai_connection_name` parameter for various input types, ensuring the parameter is correctly passed and serialized. [[1]](diffhunk://#diff-d876576dc6e270af3373c74de6e0f16c29fd25825cf8958b3d64bd361e06dfb4R53) [[2]](diffhunk://#diff-d876576dc6e270af3373c74de6e0f16c29fd25825cf8958b3d64bd361e06dfb4R83) [[3]](diffhunk://#diff-d876576dc6e270af3373c74de6e0f16c29fd25825cf8958b3d64bd361e06dfb4R140)

These changes improve the flexibility and configurability of AI service integrations in the Azure Functions decorators, while maintaining robust test coverage for the new functionality.