### PR TITLE
feat: settlement decorator changes

### DIFF
--- a/azure/functions/decorators/function_app.py
+++ b/azure/functions/decorators/function_app.py
@@ -673,6 +673,7 @@ class TriggerApi(DecoratorApi, ABC):
             access_rights: Optional[Union[AccessRights, str]] = None,
             is_sessions_enabled: Optional[bool] = None,
             cardinality: Optional[Union[Cardinality, str]] = None,
+            auto_complete_messages: Optional[bool] = None,
             **kwargs: Any) -> Callable[..., Any]:
         """
         The `on_service_bus_queue_change` decorator adds :class:`ServiceBusQueueTrigger` to the
@@ -697,6 +698,8 @@ class TriggerApi(DecoratorApi, ABC):
         :param is_sessions_enabled: Set to True if connecting to a session-aware queue
             or subscription.
         :param cardinality: Set to "many" to enable batching.
+        :param auto_complete_messages: Indicates whether the message should be automatically
+            completed.
 
         :return: Decorator function.
         """
@@ -717,6 +720,7 @@ class TriggerApi(DecoratorApi, ABC):
                         is_sessions_enabled=is_sessions_enabled,
                         cardinality=parse_singular_param_to_enum(cardinality,
                                                                  Cardinality),
+                        auto_complete_messages=auto_complete_messages,
                         **kwargs))
                 return fb
 
@@ -734,6 +738,7 @@ class TriggerApi(DecoratorApi, ABC):
             access_rights: Optional[Union[AccessRights, str]] = None,
             is_sessions_enabled: Optional[bool] = None,
             cardinality: Optional[Union[Cardinality, str]] = None,
+            auto_complete_messages: Optional[bool] = None,
             **kwargs: Any) -> Callable[..., Any]:
         """
         The `on_service_bus_topic_change` decorator adds :class:`ServiceBusTopicTrigger` to the
@@ -759,6 +764,8 @@ class TriggerApi(DecoratorApi, ABC):
         :param is_sessions_enabled: Set to True if connecting to a session-aware queue
             or subscription.
         :param cardinality: Set to "many" to enable batching.
+        :param auto_complete_messages: Indicates whether the message should be automatically
+            completed.
 
         :return: Decorator function.
         """
@@ -780,6 +787,7 @@ class TriggerApi(DecoratorApi, ABC):
                         is_sessions_enabled=is_sessions_enabled,
                         cardinality=parse_singular_param_to_enum(cardinality,
                                                                  Cardinality),
+                        auto_complete_messages=auto_complete_messages,
                         **kwargs))
                 return fb
 

--- a/tests/decorators/test_servicebus.py
+++ b/tests/decorators/test_servicebus.py
@@ -34,7 +34,7 @@ class TestServiceBus(unittest.TestCase):
             "isSessionsEnabled": True,
             "cardinality": Cardinality.ONE
         })
-    
+
     def test_service_bus_queue_trigger_autocomplete_valid_creation(self):
         trigger = ServiceBusQueueTrigger(name="req", connection="dummy_conn",
                                          queue_name="dummy_queue",

--- a/tests/decorators/test_servicebus.py
+++ b/tests/decorators/test_servicebus.py
@@ -34,6 +34,31 @@ class TestServiceBus(unittest.TestCase):
             "isSessionsEnabled": True,
             "cardinality": Cardinality.ONE
         })
+    
+    def test_service_bus_queue_trigger_autocomplete_valid_creation(self):
+        trigger = ServiceBusQueueTrigger(name="req", connection="dummy_conn",
+                                         queue_name="dummy_queue",
+                                         data_type=DataType.UNDEFINED,
+                                         access_rights=AccessRights.MANAGE,
+                                         is_sessions_enabled=True,
+                                         cardinality=Cardinality.ONE,
+                                         auto_complete_messages=True,
+                                         dummy_field="dummy")
+
+        self.assertEqual(trigger.get_binding_name(), "serviceBusTrigger")
+        self.assertEqual(trigger.get_dict_repr(), {
+            "type": SERVICE_BUS_TRIGGER,
+            "direction": BindingDirection.IN,
+            'dummyField': 'dummy',
+            "name": "req",
+            "connection": "dummy_conn",
+            "queueName": "dummy_queue",
+            "dataType": DataType.UNDEFINED,
+            "accessRights": AccessRights.MANAGE,
+            "isSessionsEnabled": True,
+            "cardinality": Cardinality.ONE,
+            "autoCompleteMessages": True
+        })
 
     def test_service_bus_queue_output_valid_creation(self):
         service_bus_queue_output = ServiceBusQueueOutput(
@@ -80,6 +105,33 @@ class TestServiceBus(unittest.TestCase):
             "accessRights": AccessRights.MANAGE,
             "isSessionsEnabled": True,
             "cardinality": Cardinality.ONE
+        })
+
+    def test_service_bus_topic_trigger_autocomplete_valid_creation(self):
+        trigger = ServiceBusTopicTrigger(name="req", connection="dummy_conn",
+                                         topic_name="dummy_topic",
+                                         subscription_name="dummy_sub",
+                                         data_type=DataType.UNDEFINED,
+                                         access_rights=AccessRights.MANAGE,
+                                         is_sessions_enabled=True,
+                                         cardinality=Cardinality.ONE,
+                                         auto_complete_messages=True,
+                                         dummy_field="dummy")
+
+        self.assertEqual(trigger.get_binding_name(), "serviceBusTrigger")
+        self.assertEqual(trigger.get_dict_repr(), {
+            "type": SERVICE_BUS_TRIGGER,
+            "direction": BindingDirection.IN,
+            'dummyField': 'dummy',
+            "name": "req",
+            "connection": "dummy_conn",
+            "topicName": "dummy_topic",
+            "subscriptionName": "dummy_sub",
+            "dataType": DataType.UNDEFINED,
+            "accessRights": AccessRights.MANAGE,
+            "isSessionsEnabled": True,
+            "cardinality": Cardinality.ONE,
+            "autoCompleteMessages": True
         })
 
     def test_service_bus_topic_output_valid_creation(self):


### PR DESCRIPTION
Message settlement requires setting the `auto_complete_messages` property in the trigger binding to false. This works currently, but the property is being sent as part of `kwargs` - it should instead be a listed parameter for customers.