### PR TITLE
feat: improve JSON error logging for Durable

### DIFF
--- a/azure/functions/durable_functions.py
+++ b/azure/functions/durable_functions.py
@@ -115,9 +115,9 @@ class ActivityTriggerConverter(meta.InConverter,
         try:
             callback = _durable_functions._serialize_custom_object
             result = json.dumps(obj, default=callback)
-        except TypeError:
+        except TypeError as e:
             raise ValueError(
-                f'activity trigger output must be json serializable ({obj})')
+                f'activity trigger output must be json serializable ({obj})') from e
 
         return meta.Datum(type='json', value=result)
 

--- a/azure/functions/durable_functions.py
+++ b/azure/functions/durable_functions.py
@@ -99,10 +99,10 @@ class ActivityTriggerConverter(meta.InConverter,
             except json.JSONDecodeError:
                 # String failover if the content is not json serializable
                 result = data.value
-            except Exception:
+            except Exception as e:
                 raise ValueError(
                     'activity trigger input must be a string or a '
-                    f'valid json serializable ({data.value})')
+                    f'valid json serializable ({data.value})') from e
         else:
             raise NotImplementedError(
                 f'unsupported activity trigger payload type: {data_type}')

--- a/tests/test_durable_functions.py
+++ b/tests/test_durable_functions.py
@@ -223,10 +223,6 @@ class TestDurableFunctions(unittest.TestCase):
             self.assertEqual(decoded, datum['expected_value'])
 
     def test_activity_trigger_decode_failure_exception_has_cause(self):
-        class NonDecodable:
-            def __init__(self):
-                self.value = 'foo'
-
         data = Datum('{"value": "bar"}', 'json')
 
         try:

--- a/tests/test_durable_functions.py
+++ b/tests/test_durable_functions.py
@@ -165,6 +165,19 @@ class TestDurableFunctions(unittest.TestCase):
                 expected_type=type(datum['output']))
             self.assertEqual(encoded, datum['expected_value'])
 
+    def test_activity_trigger_encode_failure_exception_has_cause(self):
+        class NonEncodable:
+            def __init__(self):
+                self.value = 'foo'
+
+        data = NonEncodable()
+
+        try:
+            ActivityTriggerConverter.encode(data, expected_type=None)
+        except ValueError as e:
+            self.assertIsNotNone(e.__cause__)
+            self.assertIsInstance(e.__cause__, TypeError)
+
     def test_activity_trigger_decode(self):
         # Activity Trigger allow inputs to be any JSON serializables
         # The input values to the trigger should be passed into arguments
@@ -208,6 +221,21 @@ class TestDurableFunctions(unittest.TestCase):
                 data=datum['input'],
                 trigger_metadata=None)
             self.assertEqual(decoded, datum['expected_value'])
+
+    def test_activity_trigger_decode_failure_exception_has_cause(self):
+        class NonDecodable:
+            def __init__(self):
+                self.value = 'foo'
+
+        data = Datum('{"value": "bar"}', 'json')
+
+        try:
+            ActivityTriggerConverter.decode(
+                data=data,
+                trigger_metadata=None)
+        except ValueError as e:
+            self.assertIsNotNone(e.__cause__)
+            self.assertIsInstance(e.__cause__, TypeError)
 
     def test_activity_trigger_has_implicit_return(self):
         self.assertTrue(


### PR DESCRIPTION
Currently if to_json fails, we discard the original failure and raise our own ValueError - this PR makes the new exception inherit from the original exception, making debugging serialization issues easier. 