### PR TITLE
fix: Handle comma-separated values in x-forwarded-port header

### DIFF
--- a/azure/functions/_http_wsgi.py
+++ b/azure/functions/_http_wsgi.py
@@ -113,7 +113,9 @@ class WsgiRequest:
     def _get_port(self, parsed_url, lowercased_headers: Dict[str, str]) -> int:
         port: int = 80
         if lowercased_headers.get('x-forwarded-port'):
-            return int(lowercased_headers['x-forwarded-port'])
+            # Handle comma-separated port values (e.g., "443,8080,433")
+            forwarded_port = lowercased_headers['x-forwarded-port'].split(',')[0].strip()
+            return int(forwarded_port)
         elif getattr(parsed_url, 'port', None):
             return int(parsed_url.port)
         elif parsed_url.scheme == 'https':

--- a/tests/test_http_wsgi.py
+++ b/tests/test_http_wsgi.py
@@ -100,6 +100,24 @@ class TestHttpWsgi(unittest.TestCase):
         self.assertEqual(environ['SERVER_PORT'], str(8081))
         self.assertEqual(environ['wsgi.url_scheme'], 'https')
 
+    def test_request_protocol_by_header_with_multiple_ports(self):
+        func_request = self._generate_func_request(headers={
+            "x-forwarded-port": "443,8080,433"
+        })
+        error_buffer = StringIO()
+        environ = WsgiRequest(func_request).to_environ(error_buffer)
+        self.assertEqual(environ['SERVER_PORT'], str(443))
+        self.assertEqual(environ['wsgi.url_scheme'], 'https')
+
+    def test_request_protocol_by_header_with_spaces(self):
+        func_request = self._generate_func_request(headers={
+            "x-forwarded-port": " 8443 , 8080 "
+        })
+        error_buffer = StringIO()
+        environ = WsgiRequest(func_request).to_environ(error_buffer)
+        self.assertEqual(environ['SERVER_PORT'], str(8443))
+        self.assertEqual(environ['wsgi.url_scheme'], 'https')
+
     def test_request_protocol_by_scheme(self):
         func_request = self._generate_func_request(url="http://a.b.com")
         error_buffer = StringIO()


### PR DESCRIPTION
When Azure Functions applications are deployed behind proxies or load balancers (such as Azure Application Gateway), the 'x-forwarded-port' header may contain multiple comma-separated port values (e.g., "443,8080,433"). The current implementation attempts to convert the entire string to an integer, which causes an error and subsequent function crash.

My fix extracts the first port value from this header and also strips whitespaces. Also included new tests for these

see: Azure/azure-functions-python-worker#1768