### PR TITLE
build: skip tests on 3.10 - 3.12 if version is 2.x

### DIFF
--- a/eng/templates/jobs/ci-tests.yml
+++ b/eng/templates/jobs/ci-tests.yml
@@ -20,9 +20,31 @@ jobs:
         inputs:
           versionSpec: $(PYTHON_VERSION)
       - bash: |
+          VERSION=$(python -c "import re; content = open('azure/functions/__init__.py').read(); match = re.search(r\"__version__ = '(\d+)\.(\d+)\.(\d+).*'\", content); print(match.group(1)) if match else '1'")
+          echo "##vso[task.setvariable variable=MAJOR_VERSION]$VERSION"
+        displayName: 'Detect package version'
+      - bash: |
+          PYTHON_MAJOR=$(echo $(PYTHON_VERSION) | cut -d. -f1)
+          PYTHON_MINOR=$(echo $(PYTHON_VERSION) | cut -d. -f2)
+          
+          if [ "$MAJOR_VERSION" == "2" ] && [ "$PYTHON_MINOR" -lt "13" ]; then
+            echo "Skipping tests for Python $PYTHON_VERSION on package version 2.x (requires Python 3.13+)"
+            exit 0
+          fi
+          
           python -m pip install --upgrade pip
           python -m pip install -U -e .[dev]
         displayName: 'Install dependencies'
+        condition: succeededOrFailed()
       - bash: |
+          PYTHON_MAJOR=$(echo $(PYTHON_VERSION) | cut -d. -f1)
+          PYTHON_MINOR=$(echo $(PYTHON_VERSION) | cut -d. -f2)
+          
+          if [ "$MAJOR_VERSION" == "2" ] && [ "$PYTHON_MINOR" -lt "13" ]; then
+            echo "Skipping tests for Python $PYTHON_VERSION on package version 2.x (requires Python 3.13+)"
+            exit 0
+          fi
+          
           python -m pytest --cache-clear --cov=./azure --cov-report=xml --cov-branch tests
         displayName: 'Test with pytest'
+        condition: succeededOrFailed()


### PR DESCRIPTION
If the SDK version is 2.x, skip unit tests on python 3.10 - 3.12