### PR TITLE
build: migrate to Central Feed Services

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -48,3 +48,5 @@ extends:
         dependsOn: Build
         jobs:
           - template: /eng/templates/jobs/ci-tests.yml@self
+            parameters:
+              artifactFeed: 'internal/PythonSDK_Internal_TestPackages'

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -48,3 +48,5 @@ extends:
         dependsOn: Build
         jobs:
           - template: /eng/templates/jobs/ci-tests.yml@self
+            parameters:
+              artifactFeed: 'public/PythonSDK_PublicPackages'

--- a/eng/templates/jobs/build.yml
+++ b/eng/templates/jobs/build.yml
@@ -22,6 +22,10 @@ jobs:
       - bash: |
           python --version
         displayName: 'Check python version'
+      - task: PipAuthenticate@1
+        displayName: 'Pip Authenticate'
+        inputs:
+          artifactFeeds: 'public/PythonSDK_PublicPackages'
       - bash: |
           python -m pip install -U pip
           python -m pip install build

--- a/eng/templates/jobs/ci-tests.yml
+++ b/eng/templates/jobs/ci-tests.yml
@@ -1,3 +1,7 @@
+parameters:
+  - name: artifactFeed
+    type: string
+
 jobs:
   - job: "TestPython"
     displayName: "Run Python SDK Unit Tests"
@@ -26,7 +30,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: 'public/PythonSDK_PublicPackages'
+          artifactFeeds: ${{ parameters.artifactFeed }}
       - bash: |
           PYTHON_MAJOR=$(echo $(PYTHON_VERSION) | cut -d. -f1)
           PYTHON_MINOR=$(echo $(PYTHON_VERSION) | cut -d. -f2)

--- a/eng/templates/jobs/ci-tests.yml
+++ b/eng/templates/jobs/ci-tests.yml
@@ -23,6 +23,10 @@ jobs:
           VERSION=$(python -c "import re; content = open('azure/functions/__init__.py').read(); match = re.search(r\"__version__ = '(\d+)\.(\d+)\.(\d+).*'\", content); print(match.group(1)) if match else '1'")
           echo "##vso[task.setvariable variable=MAJOR_VERSION]$VERSION"
         displayName: 'Detect package version'
+      - task: PipAuthenticate@1
+        displayName: 'Pip Authenticate'
+        inputs:
+          artifactFeeds: 'public/PythonSDK_PublicPackages'
       - bash: |
           PYTHON_MAJOR=$(echo $(PYTHON_VERSION) | cut -d. -f1)
           PYTHON_MINOR=$(echo $(PYTHON_VERSION) | cut -d. -f2)

--- a/eng/templates/official/jobs/build-artifacts.yml
+++ b/eng/templates/official/jobs/build-artifacts.yml
@@ -21,6 +21,10 @@ jobs:
       - bash: |
           python --version
         displayName: 'Check python version'
+      - task: PipAuthenticate@1
+        displayName: 'Pip Authenticate'
+        inputs:
+          artifactFeeds: 'public/PythonSDK_PublicPackages'
       - bash: |
           python -m pip install -U pip
           python -m pip install build

--- a/eng/templates/official/jobs/build-artifacts.yml
+++ b/eng/templates/official/jobs/build-artifacts.yml
@@ -24,7 +24,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: 'public/PythonSDK_PublicPackages'
+          artifactFeeds: 'internal/PythonSDK_Internal_TestPackages'
       - bash: |
           python -m pip install -U pip
           python -m pip install build

--- a/eng/templates/official/jobs/publish-release.yml
+++ b/eng/templates/official/jobs/publish-release.yml
@@ -239,6 +239,10 @@ jobs:
     displayName: 'Use Python 3.11'
     inputs:
       versionSpec: 3.11
+  - task: PipAuthenticate@1
+    displayName: 'Pip Authenticate'
+    inputs:
+      artifactFeeds: 'public/PythonSDK_PublicPackages'
   - pwsh: |
       $newLibraryVersion = "${{ parameters.libraryVersion }}"
       $pypiToken = "$(PypiToken)"

--- a/eng/templates/official/jobs/publish-release.yml
+++ b/eng/templates/official/jobs/publish-release.yml
@@ -242,7 +242,7 @@ jobs:
   - task: PipAuthenticate@1
     displayName: 'Pip Authenticate'
     inputs:
-      artifactFeeds: 'public/PythonSDK_PublicPackages'
+      artifactFeeds: internal/PythonSDK_Internal_TestPackages
   - pwsh: |
       $newLibraryVersion = "${{ parameters.libraryVersion }}"
       $pypiToken = "$(PypiToken)"


### PR DESCRIPTION
Per new security policies, packages are no longer pulled directly from pypi. Instead, they are fetched from an internal feed.