### PR TITLE
chore: add es-metadata.yml (schema 1.0.0)

### DIFF
--- a/es-metadata.yml
+++ b/es-metadata.yml
@@ -1,0 +1,12 @@
+schemaVersion: 1.0.0
+providers:
+- provider: InventoryAsCode
+  version: 1.0.0
+  metadata:
+    isProduction: true
+    accountableOwners:
+      service: e8fdf03b-44f7-48d3-8653-a744c922a342
+    routing:
+      defaultAreaPath:
+        org: azfunc
+        path: internal\Azure Functions\Core

--- a/es-metadata.yml
+++ b/es-metadata.yml
@@ -9,4 +9,4 @@ providers:
     routing:
       defaultAreaPath:
         org: azfunc
-        path: internal\Azure Functions\Core
+        path: internal\Azure Functions


### PR DESCRIPTION
Adds `es-metadata.yml` using the InventoryAsCode schema 1.0.0 format with the **Azure Functions** service tree ID.