### PR TITLE
build: Fix parse issue in release pipeline

### DIFF
--- a/eng/templates/official/release/bump-version.yml
+++ b/eng/templates/official/release/bump-version.yml
@@ -93,8 +93,9 @@ jobs:
 
           # Change version file.
           $versionFilePath = "${{ parameters.versionFilePath }}"
-          $versionPattern = '${{ parameters.versionPattern }}'
-          $versionReplacement = '${{ parameters.versionReplacement }}' -replace '\{\{VERSION\}\}', $newLibraryVersion
+          $versionPattern = $env:VERSION_PATTERN
+          $versionReplacementTemplate = $env:VERSION_REPLACEMENT
+          $versionReplacement = $versionReplacementTemplate -replace '\{\{VERSION\}\}', $newLibraryVersion
 
           Write-Host "Change version number in $versionFilePath to $newLibraryVersion"
           ((Get-Content $versionFilePath) -replace $versionPattern, $versionReplacement -join "`n") + "`n" | Set-Content -NoNewline $versionFilePath
@@ -102,10 +103,8 @@ jobs:
 
           # Update pyproject metadata when parameters are provided.
           $pyprojectPath = "${{ parameters.pyprojectPath }}"
-          $pythonVersionRequirement = "${{ parameters.pythonVersionRequirement }}"
-          $pythonClassifiers = @"
-          ${{ parameters.pythonClassifiers }}
-          "@
+          $pythonVersionRequirement = $env:PYTHON_VERSION_REQUIREMENT
+          $pythonClassifiers = $env:PYTHON_CLASSIFIERS
 
           if (![string]::IsNullOrWhiteSpace($pyprojectPath) -and (Test-Path $pyprojectPath)) {
               $content = Get-Content $pyprojectPath -Raw
@@ -161,6 +160,11 @@ jobs:
               }
           }
         displayName: 'Push ${{ parameters.releaseBranchPrefix }}/x.y.z'
+        env:
+          VERSION_PATTERN: ${{ parameters.versionPattern }}
+          VERSION_REPLACEMENT: ${{ parameters.versionReplacement }}
+          PYTHON_VERSION_REQUIREMENT: ${{ parameters.pythonVersionRequirement }}
+          PYTHON_CLASSIFIERS: ${{ parameters.pythonClassifiers }}
 
   - job: "CheckReleaseBranch"
     dependsOn: ['CreateReleaseBranch']

--- a/eng/templates/official/release/publish-release.yml
+++ b/eng/templates/official/release/publish-release.yml
@@ -85,7 +85,7 @@ jobs:
           }
 
           # Locate and validate assets before creating the release.
-          $distFolder = Join-Path '$(Pipeline.Workspace)' (Join-Path '${{ parameters.artifactName }}' 'dist')
+          $distFolder = Join-Path '$(Pipeline.Workspace)' (Join-Path "${{ parameters.artifactName }}" 'dist')
           if (-not (Test-Path -LiteralPath $distFolder)) {
               throw "Distribution folder not found: $distFolder"
           }
@@ -206,8 +206,8 @@ jobs:
           azurePowerShellVersion: LatestVersion
           pwsh: true
           Inline: |
-            $version = '${{ parameters.libraryVersion }}'
-            $blobPath = '${{ parameters.blobPath }}'
+            $version = "${{ parameters.libraryVersion }}"
+            $blobPath = "${{ parameters.blobPath }}"
             $distFolder = '$(Pipeline.Workspace)/${{ parameters.artifactName }}/dist'
 
             Write-Host "Uploading Python artifacts for version: $version"
@@ -221,7 +221,7 @@ jobs:
             azcopy copy "$distFolder/*" "https://azuresdkpartnerdrops.blob.core.windows.net/drops/$blobPath/$version/"
 
             $blobPathFull = "$blobPath/$version"
-            $partnerReleaseUrl = '${{ parameters.partnerReleasePipelineUrl }}'
+            $partnerReleaseUrl = "${{ parameters.partnerReleasePipelineUrl }}"
 
             Write-Host ""
             Write-Host "##[section]Upload complete. The partner-release pipeline will be triggered automatically in the next job."


### PR DESCRIPTION
Fixes parser error caused by single-quoted PowerShell assignments wrapping template values that themselves contain single quotes.
https://dev.azure.com/azfunc/internal/_build/results?buildId=289153&view=logs&j=6fd54042-c8d9-5a0f-dd0e-9c774ce37406&t=1215c279-6db2-57d3-0385-f2d61faced55