### PR TITLE
feat: add QUERY HTTP method support per RFC 10008

### DIFF
--- a/azure/functions/decorators/http.py
+++ b/azure/functions/decorators/http.py
@@ -16,6 +16,7 @@ class HttpMethod(StringifyEnum):
     PATCH = "PATCH"
     PUT = "PUT"
     OPTIONS = "OPTIONS"
+    QUERY = "QUERY"
 
 
 class HttpTrigger(Trigger):

--- a/tests/decorators/test_function_app.py
+++ b/tests/decorators/test_function_app.py
@@ -1012,11 +1012,12 @@ class TestFunctionApp(unittest.TestCase):
                              '{"direction": "IN", "type": "httpTrigger", '
                              '"authLevel": "FUNCTION", "route": "/{*route}", '
                              '"methods": ["GET", "POST", "DELETE", "HEAD", '
-                             '"PATCH", "PUT", "OPTIONS"], "name": "req"}'))
+                             '"PATCH", "PUT", "OPTIONS", "QUERY"], '
+                             '"name": "req"}'))
         self.assertEqual(json.loads(raw_output_binding), json.loads(
             '{"direction": "IN", "type": "httpTrigger", "authLevel": '
             '"FUNCTION", "methods": ["GET", "POST", "DELETE", "HEAD", '
-            '"PATCH", "PUT", "OPTIONS"], "name": "req", "route": "/{'
+            '"PATCH", "PUT", "OPTIONS", "QUERY"], "name": "req", "route": "/{'
             '*route}"}'))
         self.assertEqual(func.get_bindings_dict(), {
             "bindings": [
@@ -1027,7 +1028,8 @@ class TestFunctionApp(unittest.TestCase):
                                 HttpMethod.DELETE,
                                 HttpMethod.HEAD,
                                 HttpMethod.PATCH,
-                                HttpMethod.PUT, HttpMethod.OPTIONS],
+                                HttpMethod.PUT, HttpMethod.OPTIONS,
+                                HttpMethod.QUERY],
                     "name": "req",
                     "route": "/{*route}",
                     "type": HTTP_TRIGGER

--- a/tests/decorators/test_function_app.py
+++ b/tests/decorators/test_function_app.py
@@ -62,6 +62,36 @@ class TestFunction(unittest.TestCase):
                              f"is {trigger1} and New trigger "
                              f"being added is {trigger2}")
 
+    def test_function_creation_with_query_method_trigger(self):
+        output = HttpOutput(name="out", data_type=DataType.UNDEFINED)
+        trigger = HttpTrigger(name="req",
+                              methods=(HttpMethod.QUERY,),
+                              data_type=DataType.UNDEFINED,
+                              auth_level=AuthLevel.ANONYMOUS, route="dummy")
+        self.func.add_binding(output)
+        self.func.add_trigger(trigger)
+
+        assert_json(self, self.func, {"scriptFile": "dummy.py",
+                                      "bindings": [
+                                          {
+                                              "type": HTTP_OUTPUT,
+                                              "direction":
+                                                  BindingDirection.OUT,
+                                              "name": "out",
+                                              "dataType": DataType.UNDEFINED
+                                          },
+                                          {
+                                              "authLevel": AuthLevel.ANONYMOUS,
+                                              "type": HTTP_TRIGGER,
+                                              "direction": BindingDirection.IN,
+                                              "name": "req",
+                                              "dataType": DataType.UNDEFINED,
+                                              "route": "dummy",
+                                              "methods": [HttpMethod.QUERY]
+                                          }
+                                      ]
+                                      })
+
     def test_function_creation_with_binding_and_trigger(self):
         output = HttpOutput(name="out", data_type=DataType.UNDEFINED)
         trigger = HttpTrigger(name="req",

--- a/tests/decorators/test_http.py
+++ b/tests/decorators/test_http.py
@@ -14,7 +14,7 @@ class TestHttp(unittest.TestCase):
         self.assertEqual([e for e in HttpMethod],
                          [HttpMethod.GET, HttpMethod.POST, HttpMethod.DELETE,
                           HttpMethod.HEAD, HttpMethod.PATCH, HttpMethod.PUT,
-                          HttpMethod.OPTIONS])
+                          HttpMethod.OPTIONS, HttpMethod.QUERY])
 
     def test_http_trigger_valid_creation_with_methods(self):
         http_trigger = HttpTrigger(name='req',

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -211,6 +211,23 @@ class TestHTTP(unittest.TestCase):
             "dummy_params_key": "dummy_params_value"}))
         self.assertEqual(http_request.get_body(), b"test_body")
 
+    def test_http_request_converter_decode_query_method(self):
+        data = {
+            "method": Datum("QUERY", "string"),
+            "url": Datum("www.dummy.com/products", "string"),
+            "headers": {'Content-Type': Datum("application/json", "string")},
+            "query": {},
+            "params": {},
+            "body": Datum('{"category": "laptops"}', "string")
+        }
+        datum = Datum(data, "http")
+
+        http_request = http.HttpRequestConverter.decode(
+            data=datum, trigger_metadata={})
+
+        self.assertEqual(http_request.method, "QUERY")
+        self.assertEqual(http_request.get_body(), b'{"category": "laptops"}')
+
     def test_http_with_bytes_data(self):
         data = (
             b"--foo\r\n"

--- a/tests/test_http_asgi.py
+++ b/tests/test_http_asgi.py
@@ -70,7 +70,7 @@ class MockAsgiApplication:
             assert isinstance(scope['http_version'], str)
 
             assert scope['method'] in ['POST', 'GET', 'PUT', 'DELETE', 'PATCH',
-                                        'QUERY']
+                                       'QUERY']
             assert isinstance(scope['method'], str)
 
             assert scope['scheme'] in ['http', 'https']

--- a/tests/test_http_asgi.py
+++ b/tests/test_http_asgi.py
@@ -69,7 +69,8 @@ class MockAsgiApplication:
             assert scope['http_version'] in ['1.0', '1.1', '2']
             assert isinstance(scope['http_version'], str)
 
-            assert scope['method'] in ['POST', 'GET', 'PUT', 'DELETE', 'PATCH']
+            assert scope['method'] in ['POST', 'GET', 'PUT', 'DELETE', 'PATCH',
+                                        'QUERY']
             assert isinstance(scope['method'], str)
 
             assert scope['scheme'] in ['http', 'https']


### PR DESCRIPTION
Adds HttpMethod.QUERY to the HttpMethod enum so Azure Functions HTTP triggers can declare and handle the new QUERY method (RFC 10008), which provides a safe, read-only alternative to POST for requests requiring a body.