### PR TITLE
fix: address inconsistent serialization for binding objects

### DIFF
--- a/azure/functions/_abc.py
+++ b/azure/functions/_abc.py
@@ -16,12 +16,16 @@ T = typing.TypeVar('T')
 class Serializable(abc.ABC):
     """Mixin that provides a uniform serialization contract for binding types.
 
-    Concrete binding classes must implement :meth:`to_dict`.  A default
-    :meth:`to_json` implementation is provided that serializes the result of
-    :meth:`to_dict` to a JSON string.
+    Binding classes should override :meth:`to_dict` to return a JSON-safe
+    representation.  A default :meth:`to_json` implementation is provided
+    that serializes the result of :meth:`to_dict` to a JSON string.
+
+    :meth:`to_dict` is intentionally non-abstract so that downstream
+    subclasses of the binding ABCs that predate this contract are not broken
+    at instantiation time.  Calling ``to_dict()`` on a class that has not
+    implemented it raises :exc:`NotImplementedError` at call time.
     """
 
-    @abc.abstractmethod
     def to_dict(self) -> typing.Any:
         """Return a JSON-safe representation of this binding object.
 
@@ -30,8 +34,14 @@ class Serializable(abc.ABC):
         All ``bytes`` values are decoded as UTF-8 when possible, otherwise
         represented as ``{"__encoding": "base64", "value": "<base64>"}``.
         All ``datetime`` values are represented as ISO-8601 strings.
+
+        Subclasses that do not override this method will raise
+        :exc:`NotImplementedError` at call time rather than at instantiation.
         """
-        ...
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement to_dict(). "
+            "Override this method to enable serialization."
+        )
 
     def to_json(self) -> str:
         """Return the JSON string representation of this binding object.

--- a/azure/functions/_abc.py
+++ b/azure/functions/_abc.py
@@ -4,12 +4,42 @@
 import abc
 import datetime
 import io
+import json
 import threading
 import typing
 
 from werkzeug.datastructures import Headers
 
 T = typing.TypeVar('T')
+
+
+class Serializable(abc.ABC):
+    """Mixin that provides a uniform serialization contract for binding types.
+
+    Concrete binding classes must implement :meth:`to_dict`.  A default
+    :meth:`to_json` implementation is provided that serializes the result of
+    :meth:`to_dict` to a JSON string.
+    """
+
+    @abc.abstractmethod
+    def to_dict(self) -> typing.Any:
+        """Return a JSON-safe representation of this binding object.
+
+        Non-list binding types return a ``dict``; collection types such as
+        ``DocumentList`` or ``SqlRowList`` return a ``list`` of ``dict``.
+        All ``bytes`` values are decoded as UTF-8 when possible, otherwise
+        represented as ``{"__encoding": "base64", "value": "<base64>"}``.
+        All ``datetime`` values are represented as ISO-8601 strings.
+        """
+        ...
+
+    def to_json(self) -> str:
+        """Return the JSON string representation of this binding object.
+
+        Delegates to :meth:`to_dict`; subclasses should override
+        :meth:`to_dict` rather than this method.
+        """
+        return json.dumps(self.to_dict())
 
 
 class Out(abc.ABC, typing.Generic[T]):
@@ -215,7 +245,7 @@ class HttpResponse(abc.ABC):
         pass
 
 
-class TimerRequest(abc.ABC):
+class TimerRequest(Serializable):
     """Timer request object."""
 
     @property
@@ -225,7 +255,7 @@ class TimerRequest(abc.ABC):
         pass
 
 
-class InputStream(io.BufferedIOBase, abc.ABC):
+class InputStream(io.BufferedIOBase, Serializable):
     """File-like object representing an input blob."""
 
     @abc.abstractmethod
@@ -261,7 +291,7 @@ class InputStream(io.BufferedIOBase, abc.ABC):
         pass
 
 
-class QueueMessage(abc.ABC):
+class QueueMessage(Serializable):
 
     @property
     @abc.abstractmethod
@@ -302,7 +332,7 @@ class QueueMessage(abc.ABC):
         pass
 
 
-class EventGridEvent(abc.ABC):
+class EventGridEvent(Serializable):
     @property
     @abc.abstractmethod
     def id(self) -> str:
@@ -338,7 +368,7 @@ class EventGridEvent(abc.ABC):
         pass
 
 
-class EventGridOutputEvent(abc.ABC):
+class EventGridOutputEvent(Serializable):
     @property
     @abc.abstractmethod
     def id(self) -> str:
@@ -369,7 +399,7 @@ class EventGridOutputEvent(abc.ABC):
         pass
 
 
-class CloudEvent(abc.ABC):
+class CloudEvent(Serializable):
     """A CloudEvents v1.0 event message."""
 
     @property
@@ -417,7 +447,7 @@ class CloudEvent(abc.ABC):
         pass
 
 
-class Document(abc.ABC):
+class Document(Serializable):
 
     @classmethod
     @abc.abstractmethod
@@ -438,19 +468,15 @@ class Document(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def to_json(self) -> str:
-        pass
-
-    @abc.abstractmethod
     def to_dict(self) -> dict:
         pass
 
 
-class DocumentList(abc.ABC):
+class DocumentList(Serializable):
     pass
 
 
-class EventHubEvent(abc.ABC):
+class EventHubEvent(Serializable):
 
     @abc.abstractmethod
     def get_body(self) -> bytes:
@@ -489,7 +515,7 @@ class OrchestrationContext(abc.ABC):
         pass
 
 
-class ServiceBusMessage(abc.ABC):
+class ServiceBusMessage(Serializable):
 
     @abc.abstractmethod
     def get_body(self) -> typing.Union[str, bytes]:

--- a/azure/functions/_abc.py
+++ b/azure/functions/_abc.py
@@ -4,7 +4,7 @@
 import abc
 import datetime
 import io
-import json
+from ._jsonutils import json
 import threading
 import typing
 

--- a/azure/functions/_blob.py
+++ b/azure/functions/_blob.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+import typing
 from typing import Optional
 
 from azure.functions import _abc as azf_abc
@@ -53,3 +54,14 @@ class InputStream(azf_abc.InputStream):
             Bytes read from the input stream.
         """
         return self._io.read(size)
+
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        """Return a JSON-safe dictionary of blob metadata fields.
+
+        Blob content is intentionally excluded; use :meth:`read` to access it.
+        """
+        return {
+            'name': self._name,
+            'uri': self._uri,
+            'length': self._length,
+        }

--- a/azure/functions/_cosmosdb.py
+++ b/azure/functions/_cosmosdb.py
@@ -46,4 +46,7 @@ class Document(_abc.Document, collections.UserDict):
 
 class DocumentList(_abc.DocumentList, collections.UserList):
     "A ``UserList`` subclass containing a list of :class:`~Document` objects"
-    pass
+
+    def to_dict(self):
+        """Return a list of JSON-safe dicts, one per :class:`~Document`."""
+        return [doc.to_dict() for doc in self]

--- a/azure/functions/_eventgrid.py
+++ b/azure/functions/_eventgrid.py
@@ -137,7 +137,7 @@ class EventGridOutputEvent(azf_abc.EventGridOutputEvent):
             'event_type': self.event_type,
             'event_time': _serialize_value(self.event_time),
             'data_version': self.data_version,
-'data': _serialize_value(self.get_json()),
+            'data': _serialize_value(self.get_json()),
         }
 
 

--- a/azure/functions/_eventgrid.py
+++ b/azure/functions/_eventgrid.py
@@ -74,7 +74,7 @@ class EventGridEvent(azf_abc.EventGridEvent):
             'event_type': self.event_type,
             'event_time': _serialize_value(self.event_time),
             'data_version': self.data_version,
-            'data': self.get_json(),
+            'data': _serialize_value(self.get_json()),
         }
 
 
@@ -229,6 +229,6 @@ class CloudEvent(azf_abc.CloudEvent):
             'time': _serialize_value(self.time),
             'datacontenttype': self.datacontenttype,
             'dataschema': self.dataschema,
-            'data': self.get_json(),
-            'extension_attrs': self.extension_attrs,
+            'data': _serialize_value(self.get_json()),
+            'extension_attrs': _serialize_value(self.extension_attrs),
         }

--- a/azure/functions/_eventgrid.py
+++ b/azure/functions/_eventgrid.py
@@ -137,7 +137,7 @@ class EventGridOutputEvent(azf_abc.EventGridOutputEvent):
             'event_type': self.event_type,
             'event_time': _serialize_value(self.event_time),
             'data_version': self.data_version,
-            'data': self.get_json(),
+'data': _serialize_value(self.get_json()),
         }
 
 

--- a/azure/functions/_eventgrid.py
+++ b/azure/functions/_eventgrid.py
@@ -61,6 +61,22 @@ class EventGridEvent(azf_abc.EventGridEvent):
             f'at 0x{id(self):0x}>'
         )
 
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        """Return a JSON-safe dictionary of all EventGrid event fields.
+
+        ``event_time`` is represented as an ISO-8601 string.
+        """
+        from ._utils import _serialize_value
+        return {
+            'id': self.id,
+            'topic': self.topic,
+            'subject': self.subject,
+            'event_type': self.event_type,
+            'event_time': _serialize_value(self.event_time),
+            'data_version': self.data_version,
+            'data': self.get_json(),
+        }
+
 
 class EventGridOutputEvent(azf_abc.EventGridOutputEvent):
     """An EventGrid event message."""
@@ -109,6 +125,21 @@ class EventGridOutputEvent(azf_abc.EventGridOutputEvent):
             f'subject={self.subject} '
             f'at 0x{id(self):0x}>'
         )
+
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        """Return a JSON-safe dictionary of all EventGrid output event fields.
+
+        ``event_time`` is represented as an ISO-8601 string.
+        """
+        from ._utils import _serialize_value
+        return {
+            'id': self.id,
+            'subject': self.subject,
+            'event_type': self.event_type,
+            'event_time': _serialize_value(self.event_time),
+            'data_version': self.data_version,
+            'data': self.get_json(),
+        }
 
 
 class CloudEvent(azf_abc.CloudEvent):
@@ -182,3 +213,22 @@ class CloudEvent(azf_abc.CloudEvent):
             f'type={self.type} '
             f'at 0x{id(self):0x}>'
         )
+
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        """Return a JSON-safe dictionary of all CloudEvent fields.
+
+        ``time`` is represented as an ISO-8601 string.
+        """
+        from ._utils import _serialize_value
+        return {
+            'id': self.id,
+            'source': self.source,
+            'type': self.type,
+            'specversion': self.specversion,
+            'subject': self.subject,
+            'time': _serialize_value(self.time),
+            'datacontenttype': self.datacontenttype,
+            'dataschema': self.dataschema,
+            'data': self.get_json(),
+            'extension_attrs': self.extension_attrs,
+        }

--- a/azure/functions/_eventgrid.py
+++ b/azure/functions/_eventgrid.py
@@ -5,6 +5,7 @@ import datetime
 import typing
 
 from azure.functions import _abc as azf_abc
+from ._utils import _serialize_value
 
 
 class EventGridEvent(azf_abc.EventGridEvent):
@@ -66,7 +67,6 @@ class EventGridEvent(azf_abc.EventGridEvent):
 
         ``event_time`` is represented as an ISO-8601 string.
         """
-        from ._utils import _serialize_value
         return {
             'id': self.id,
             'topic': self.topic,
@@ -131,7 +131,6 @@ class EventGridOutputEvent(azf_abc.EventGridOutputEvent):
 
         ``event_time`` is represented as an ISO-8601 string.
         """
-        from ._utils import _serialize_value
         return {
             'id': self.id,
             'subject': self.subject,
@@ -219,7 +218,6 @@ class CloudEvent(azf_abc.CloudEvent):
 
         ``time`` is represented as an ISO-8601 string.
         """
-        from ._utils import _serialize_value
         return {
             'id': self.id,
             'source': self.source,

--- a/azure/functions/_eventhub.py
+++ b/azure/functions/_eventhub.py
@@ -80,6 +80,24 @@ class EventHubEvent(func_abc.EventHubEvent):
             }
         return self._trigger_metadata_pyobj
 
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        """Return a JSON-safe dictionary of all Event Hub event fields.
+
+        ``body`` bytes are decoded as UTF-8 when valid, otherwise represented
+        as ``{"__encoding": "base64", "value": "<base64>"}``.
+        ``enqueued_time`` is an ISO-8601 string.
+        """
+        from ._utils import _serialize_value
+        return {
+            'body': _serialize_value(self.get_body()),
+            'partition_key': self.partition_key,
+            'sequence_number': self.sequence_number,
+            'offset': self.offset,
+            'enqueued_time': _serialize_value(self.enqueued_time),
+            'iothub_metadata': (dict(self.iothub_metadata)
+                                if self.iothub_metadata else None),
+        }
+
     def __repr__(self) -> str:
         return (
             f'<azure.EventHubEvent '

--- a/azure/functions/_eventhub.py
+++ b/azure/functions/_eventhub.py
@@ -6,6 +6,7 @@ import typing
 
 from azure.functions import _abc as func_abc
 from azure.functions import meta
+from ._utils import _serialize_value
 
 
 class EventHubEvent(func_abc.EventHubEvent):
@@ -87,7 +88,6 @@ class EventHubEvent(func_abc.EventHubEvent):
         as ``{"__encoding": "base64", "value": "<base64>"}``.
         ``enqueued_time`` is an ISO-8601 string.
         """
-        from ._utils import _serialize_value
         return {
             'body': _serialize_value(self.get_body()),
             'partition_key': self.partition_key,

--- a/azure/functions/_kafka.py
+++ b/azure/functions/_kafka.py
@@ -4,8 +4,10 @@
 import abc
 import typing
 
+from . import _abc
 
-class AbstractKafkaEvent(abc.ABC):
+
+class AbstractKafkaEvent(_abc.Serializable):
 
     @abc.abstractmethod
     def get_body(self) -> bytes:

--- a/azure/functions/_mysql.py
+++ b/azure/functions/_mysql.py
@@ -81,5 +81,4 @@ class MySqlRowList(BaseMySqlRowList, collections.UserList):
 
     def to_json(self) -> str:
         """Return the JSON representation of the MySqlRowList."""
-        import json as _stdlib_json
-        return _stdlib_json.dumps(self.to_dict())
+        return json.dumps(self.to_dict())

--- a/azure/functions/_mysql.py
+++ b/azure/functions/_mysql.py
@@ -54,7 +54,7 @@ class MySqlRow(BaseMySqlRow, collections.UserDict):
 
     def to_json(self) -> str:
         """Return the JSON representation of the MySqlRow"""
-        return json.dumps(dict(self))
+        return json.dumps(self.to_dict())
 
     def to_dict(self) -> dict:
         """Return the MySqlRow as a plain dict."""

--- a/azure/functions/_mysql.py
+++ b/azure/functions/_mysql.py
@@ -4,6 +4,7 @@ import abc
 import collections
 
 from ._jsonutils import json
+from ._utils import _serialize_value
 
 
 class BaseMySqlRow(abc.ABC):
@@ -57,7 +58,6 @@ class MySqlRow(BaseMySqlRow, collections.UserDict):
 
     def to_dict(self) -> dict:
         """Return the MySqlRow as a plain dict."""
-        from ._utils import _serialize_value
         return _serialize_value(dict(self))
 
     def __getitem__(self, key):

--- a/azure/functions/_mysql.py
+++ b/azure/functions/_mysql.py
@@ -55,6 +55,10 @@ class MySqlRow(BaseMySqlRow, collections.UserDict):
         """Return the JSON representation of the MySqlRow"""
         return json.dumps(dict(self))
 
+    def to_dict(self) -> dict:
+        """Return the MySqlRow as a plain dict."""
+        return dict(self)
+
     def __getitem__(self, key):
         return collections.UserDict.__getitem__(self, key)
 
@@ -69,4 +73,12 @@ class MySqlRow(BaseMySqlRow, collections.UserDict):
 
 class MySqlRowList(BaseMySqlRowList, collections.UserList):
     "A ''UserList'' subclass containing a list of :class:'~MySqlRow' objects"
-    pass
+
+    def to_dict(self):
+        """Return a list of plain dicts, one per :class:`~MySqlRow`."""
+        return [row.to_dict() for row in self]
+
+    def to_json(self) -> str:
+        """Return the JSON representation of the MySqlRowList."""
+        import json as _stdlib_json
+        return _stdlib_json.dumps(self.to_dict())

--- a/azure/functions/_mysql.py
+++ b/azure/functions/_mysql.py
@@ -57,7 +57,8 @@ class MySqlRow(BaseMySqlRow, collections.UserDict):
 
     def to_dict(self) -> dict:
         """Return the MySqlRow as a plain dict."""
-        return dict(self)
+        from ._utils import _serialize_value
+        return _serialize_value(dict(self))
 
     def __getitem__(self, key):
         return collections.UserDict.__getitem__(self, key)

--- a/azure/functions/_queue.py
+++ b/azure/functions/_queue.py
@@ -6,6 +6,7 @@ import typing
 
 from . import _abc
 from ._jsonutils import json
+from ._utils import _serialize_value
 
 
 class QueueMessage(_abc.QueueMessage):
@@ -95,7 +96,6 @@ class QueueMessage(_abc.QueueMessage):
         as ``{"__encoding": "base64", "value": "<base64>"}``.
         Datetime fields are ISO-8601 strings.
         """
-        from ._utils import _serialize_value
         return {
             'id': self.id,
             'body': _serialize_value(self.get_body()),

--- a/azure/functions/_queue.py
+++ b/azure/functions/_queue.py
@@ -88,6 +88,24 @@ class QueueMessage(_abc.QueueMessage):
         """
         return json.loads(self.__body)
 
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        """Return a JSON-safe dictionary of all message fields.
+
+        ``body`` bytes are decoded as UTF-8 when valid, otherwise represented
+        as ``{"__encoding": "base64", "value": "<base64>"}``.
+        Datetime fields are ISO-8601 strings.
+        """
+        from ._utils import _serialize_value
+        return {
+            'id': self.id,
+            'body': _serialize_value(self.get_body()),
+            'pop_receipt': self.pop_receipt,
+            'dequeue_count': self.dequeue_count,
+            'expiration_time': _serialize_value(self.expiration_time),
+            'insertion_time': _serialize_value(self.insertion_time),
+            'time_next_visible': _serialize_value(self.time_next_visible),
+        }
+
     def __repr__(self) -> str:
         return (
             f'<azure.QueueMessage id={self.id} at 0x{id(self):0x}>'

--- a/azure/functions/_servicebus.py
+++ b/azure/functions/_servicebus.py
@@ -464,3 +464,44 @@ class ServiceBusMessage(_abc.ServiceBusMessage):
     def get_body(self) -> bytes:
         """Return message content as bytes."""
         return self.__body
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-safe dictionary of all Service Bus message fields.
+
+        ``body`` bytes are decoded as UTF-8 when valid, otherwise represented
+        as ``{"__encoding": "base64", "value": "<base64>"}``.
+        Datetime fields are ISO-8601 strings; ``time_to_live`` is a string
+        representation of the ``timedelta``.
+        """
+        from ._utils import _serialize_value
+        ttl = self.time_to_live
+        return {
+            'body': _serialize_value(self.get_body()),
+            'application_properties': self.application_properties,
+            'content_type': self.content_type,
+            'correlation_id': self.correlation_id,
+            'dead_letter_error_description': self.dead_letter_error_description,
+            'dead_letter_reason': self.dead_letter_reason,
+            'dead_letter_source': self.dead_letter_source,
+            'delivery_count': self.delivery_count,
+            'enqueued_sequence_number': self.enqueued_sequence_number,
+            'enqueued_time_utc': _serialize_value(self.enqueued_time_utc),
+            'expires_at_utc': _serialize_value(self.expires_at_utc),
+            'label': self.label,
+            'locked_until': _serialize_value(self.locked_until),
+            'lock_token': self.lock_token,
+            'message_id': self.message_id,
+            'partition_key': self.partition_key,
+            'reply_to': self.reply_to,
+            'reply_to_session_id': self.reply_to_session_id,
+            'scheduled_enqueue_time_utc': _serialize_value(
+                self.scheduled_enqueue_time_utc),
+            'sequence_number': self.sequence_number,
+            'session_id': self.session_id,
+            'state': self.state,
+            'subject': self.subject,
+            'time_to_live': str(ttl) if ttl is not None else None,
+            'to': self.to,
+            'transaction_partition_key': self.transaction_partition_key,
+            'user_properties': self.user_properties,
+        }

--- a/azure/functions/_servicebus.py
+++ b/azure/functions/_servicebus.py
@@ -477,7 +477,7 @@ class ServiceBusMessage(_abc.ServiceBusMessage):
         ttl = self.time_to_live
         return {
             'body': _serialize_value(self.get_body()),
-            'application_properties': self.application_properties,
+            'application_properties': _serialize_value(self.application_properties),
             'content_type': self.content_type,
             'correlation_id': self.correlation_id,
             'dead_letter_error_description': self.dead_letter_error_description,
@@ -503,5 +503,5 @@ class ServiceBusMessage(_abc.ServiceBusMessage):
             'time_to_live': str(ttl) if ttl is not None else None,
             'to': self.to,
             'transaction_partition_key': self.transaction_partition_key,
-            'user_properties': self.user_properties,
+            'user_properties': _serialize_value(self.user_properties),
         }

--- a/azure/functions/_servicebus.py
+++ b/azure/functions/_servicebus.py
@@ -5,6 +5,7 @@ import datetime
 from typing import Optional, Dict, Any, Union
 
 from . import _abc
+from ._utils import _serialize_value
 
 
 class ServiceBusMessage(_abc.ServiceBusMessage):
@@ -473,7 +474,6 @@ class ServiceBusMessage(_abc.ServiceBusMessage):
         Datetime fields are ISO-8601 strings; ``time_to_live`` is a string
         representation of the ``timedelta``.
         """
-        from ._utils import _serialize_value
         ttl = self.time_to_live
         return {
             'body': _serialize_value(self.get_body()),

--- a/azure/functions/_sql.py
+++ b/azure/functions/_sql.py
@@ -81,5 +81,4 @@ class SqlRowList(BaseSqlRowList, collections.UserList):
 
     def to_json(self) -> str:
         """Return the JSON representation of the SqlRowList."""
-        import json as _stdlib_json
-        return _stdlib_json.dumps(self.to_dict())
+        return json.dumps(self.to_dict())

--- a/azure/functions/_sql.py
+++ b/azure/functions/_sql.py
@@ -4,6 +4,7 @@ import abc
 import collections
 
 from ._jsonutils import json
+from ._utils import _serialize_value
 
 
 class BaseSqlRow(abc.ABC):
@@ -57,7 +58,6 @@ class SqlRow(BaseSqlRow, collections.UserDict):
 
     def to_dict(self) -> dict:
         """Return the SqlRow as a plain dict."""
-        from ._utils import _serialize_value
         return _serialize_value(dict(self))
 
     def __getitem__(self, key):

--- a/azure/functions/_sql.py
+++ b/azure/functions/_sql.py
@@ -55,6 +55,10 @@ class SqlRow(BaseSqlRow, collections.UserDict):
         """Return the JSON representation of the SqlRow"""
         return json.dumps(dict(self))
 
+    def to_dict(self) -> dict:
+        """Return the SqlRow as a plain dict."""
+        return dict(self)
+
     def __getitem__(self, key):
         return collections.UserDict.__getitem__(self, key)
 
@@ -69,4 +73,12 @@ class SqlRow(BaseSqlRow, collections.UserDict):
 
 class SqlRowList(BaseSqlRowList, collections.UserList):
     "A ''UserList'' subclass containing a list of :class:'~SqlRow' objects"
-    pass
+
+    def to_dict(self):
+        """Return a list of plain dicts, one per :class:`~SqlRow`."""
+        return [row.to_dict() for row in self]
+
+    def to_json(self) -> str:
+        """Return the JSON representation of the SqlRowList."""
+        import json as _stdlib_json
+        return _stdlib_json.dumps(self.to_dict())

--- a/azure/functions/_sql.py
+++ b/azure/functions/_sql.py
@@ -57,7 +57,8 @@ class SqlRow(BaseSqlRow, collections.UserDict):
 
     def to_dict(self) -> dict:
         """Return the SqlRow as a plain dict."""
-        return dict(self)
+        from ._utils import _serialize_value
+        return _serialize_value(dict(self))
 
     def __getitem__(self, key):
         return collections.UserDict.__getitem__(self, key)

--- a/azure/functions/_sql.py
+++ b/azure/functions/_sql.py
@@ -54,7 +54,7 @@ class SqlRow(BaseSqlRow, collections.UserDict):
 
     def to_json(self) -> str:
         """Return the JSON representation of the SqlRow"""
-        return json.dumps(dict(self))
+        return json.dumps(self.to_dict())
 
     def to_dict(self) -> dict:
         """Return the SqlRow as a plain dict."""

--- a/azure/functions/_timer.py
+++ b/azure/functions/_timer.py
@@ -18,3 +18,9 @@ class TimerRequest(_abc.TimerRequest):
     def past_due(self) -> bool:
         """Whether the timer is past due."""
         return self.__past_due
+
+    def to_dict(self):
+        """Return a JSON-safe dictionary of timer request fields."""
+        return {
+            'past_due': self.past_due,
+        }

--- a/azure/functions/_utils.py
+++ b/azure/functions/_utils.py
@@ -29,6 +29,10 @@ def _serialize_value(v: Any) -> Any:
         return v.isoformat()
     if isinstance(v, _dt.timedelta):
         return str(v)
+    if isinstance(v, dict):
+        return {k: _serialize_value(val) for k, val in v.items()}
+    if isinstance(v, (list, tuple)):
+        return [_serialize_value(item) for item in v]
     return v
 
 

--- a/azure/functions/_utils.py
+++ b/azure/functions/_utils.py
@@ -15,6 +15,8 @@ def _serialize_value(v: Any) -> Any:
     - ``datetime.datetime`` / ``datetime.date``: ISO-8601 string via
       ``.isoformat()``.
     - ``datetime.timedelta``: ``str(v)`` (e.g. ``"0:05:00"``).
+    - ``dict`` / ``list`` / ``tuple``: normalized recursively by applying this
+      function to nested values.
     - All other types: returned unchanged.
     """
     if isinstance(v, bytes):

--- a/azure/functions/_utils.py
+++ b/azure/functions/_utils.py
@@ -1,8 +1,35 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from typing import List, Tuple, Optional
+import base64
+import datetime as _dt
+from typing import Any, List, Tuple, Optional
 from datetime import datetime, timedelta
+
+
+def _serialize_value(v: Any) -> Any:
+    """Normalize a single field value to a JSON-safe type.
+
+    - ``bytes``: decoded as UTF-8 when valid, otherwise base64-encoded as
+      ``{"__encoding": "base64", "value": "<base64>"}``.
+    - ``datetime.datetime`` / ``datetime.date``: ISO-8601 string via
+      ``.isoformat()``.
+    - ``datetime.timedelta``: ``str(v)`` (e.g. ``"0:05:00"``).
+    - All other types: returned unchanged.
+    """
+    if isinstance(v, bytes):
+        try:
+            return v.decode('utf-8')
+        except UnicodeDecodeError:
+            return {
+                '__encoding': 'base64',
+                'value': base64.b64encode(v).decode('ascii'),
+            }
+    if isinstance(v, (_dt.datetime, _dt.date)):
+        return v.isoformat()
+    if isinstance(v, _dt.timedelta):
+        return str(v)
+    return v
 
 
 def try_parse_datetime_with_formats(

--- a/azure/functions/blob.py
+++ b/azure/functions/blob.py
@@ -62,12 +62,13 @@ class InputStream(azf_blob.InputStream):
 
         Blob content is intentionally excluded; use :meth:`read` to access it.
         """
+        from ._utils import _serialize_value
         return {
             'name': self._name,
             'uri': self._uri,
             'length': self._length,
-            'blob_properties': self._blob_properties,
-            'metadata': self._metadata,
+            'blob_properties': _serialize_value(self._blob_properties),
+            'metadata': _serialize_value(self._metadata),
         }
 
 

--- a/azure/functions/blob.py
+++ b/azure/functions/blob.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import io
+import typing
 from typing import Any, Optional, Union
 
 from azure.functions import _abc as azf_abc
@@ -55,6 +56,19 @@ class InputStream(azf_blob.InputStream):
 
     def writable(self) -> bool:
         return False
+
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        """Return a JSON-safe dictionary of blob metadata fields.
+
+        Blob content is intentionally excluded; use :meth:`read` to access it.
+        """
+        return {
+            'name': self._name,
+            'uri': self._uri,
+            'length': self._length,
+            'blob_properties': self._blob_properties,
+            'metadata': self._metadata,
+        }
 
 
 class BlobConverter(meta.InConverter,

--- a/azure/functions/blob.py
+++ b/azure/functions/blob.py
@@ -8,6 +8,7 @@ from typing import Any, Optional, Union
 from azure.functions import _abc as azf_abc
 from azure.functions import _blob as azf_blob
 from . import meta
+from ._utils import _serialize_value
 
 
 class InputStream(azf_blob.InputStream):
@@ -62,7 +63,6 @@ class InputStream(azf_blob.InputStream):
 
         Blob content is intentionally excluded; use :meth:`read` to access it.
         """
-        from ._utils import _serialize_value
         return {
             'name': self._name,
             'uri': self._uri,

--- a/azure/functions/kafka.py
+++ b/azure/functions/kafka.py
@@ -77,6 +77,23 @@ class KafkaEvent(AbstractKafkaEvent):
 
         return self._trigger_metadata_pyobj
 
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        """Return a JSON-safe dictionary of all Kafka event fields.
+
+        ``body`` bytes are decoded as UTF-8 when valid, otherwise represented
+        as ``{"__encoding": "base64", "value": "<base64>"}``.
+        """
+        from ._utils import _serialize_value
+        return {
+            'body': _serialize_value(self.get_body()),
+            'key': self.key,
+            'offset': self.offset,
+            'partition': self.partition,
+            'topic': self.topic,
+            'timestamp': self.timestamp,
+            'headers': self.headers,
+        }
+
     def __repr__(self) -> str:
         return (
             f'<azure.KafkaEvent '

--- a/azure/functions/kafka.py
+++ b/azure/functions/kafka.py
@@ -91,7 +91,7 @@ class KafkaEvent(AbstractKafkaEvent):
             'partition': self.partition,
             'topic': self.topic,
             'timestamp': self.timestamp,
-            'headers': self.headers,
+            'headers': _serialize_value(self.headers),
         }
 
     def __repr__(self) -> str:

--- a/azure/functions/kafka.py
+++ b/azure/functions/kafka.py
@@ -9,6 +9,7 @@ from . import meta
 from ._jsonutils import json
 
 from ._kafka import AbstractKafkaEvent
+from ._utils import _serialize_value
 
 
 class KafkaEvent(AbstractKafkaEvent):
@@ -83,7 +84,6 @@ class KafkaEvent(AbstractKafkaEvent):
         ``body`` bytes are decoded as UTF-8 when valid, otherwise represented
         as ``{"__encoding": "base64", "value": "<base64>"}``.
         """
-        from ._utils import _serialize_value
         return {
             'body': _serialize_value(self.get_body()),
             'key': self.key,

--- a/azure/functions/timer.py
+++ b/azure/functions/timer.py
@@ -27,6 +27,14 @@ class TimerRequest(azf_timer.TimerRequest):
     def schedule(self) -> dict:
         return self.__schedule
 
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        """Return a JSON-safe dictionary of all timer request fields."""
+        return {
+            'past_due': self.past_due,
+            'schedule_status': self.schedule_status,
+            'schedule': self.schedule,
+        }
+
 
 class TimerRequestConverter(meta.InConverter,
                             binding='timerTrigger', trigger=True):

--- a/azure/functions/timer.py
+++ b/azure/functions/timer.py
@@ -7,6 +7,7 @@ from azure.functions import _abc as azf_abc
 from azure.functions import _timer as azf_timer
 from . import meta
 from ._jsonutils import json
+from ._utils import _serialize_value
 
 
 class TimerRequest(azf_timer.TimerRequest):
@@ -29,7 +30,6 @@ class TimerRequest(azf_timer.TimerRequest):
 
 def to_dict(self) -> typing.Dict[str, typing.Any]:
     """Return a JSON-safe dictionary of all timer request fields."""
-    from ._utils import _serialize_value
 
     return {
         'past_due': self.past_due,

--- a/azure/functions/timer.py
+++ b/azure/functions/timer.py
@@ -28,14 +28,14 @@ class TimerRequest(azf_timer.TimerRequest):
     def schedule(self) -> dict:
         return self.__schedule
 
-def to_dict(self) -> typing.Dict[str, typing.Any]:
-    """Return a JSON-safe dictionary of all timer request fields."""
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        """Return a JSON-safe dictionary of all timer request fields."""
 
-    return {
-        'past_due': self.past_due,
-        'schedule_status': _serialize_value(self.schedule_status),
-        'schedule': _serialize_value(self.schedule),
-    }
+        return {
+            'past_due': self.past_due,
+            'schedule_status': _serialize_value(self.schedule_status),
+            'schedule': _serialize_value(self.schedule),
+        }
 
 
 class TimerRequestConverter(meta.InConverter,

--- a/azure/functions/timer.py
+++ b/azure/functions/timer.py
@@ -27,13 +27,15 @@ class TimerRequest(azf_timer.TimerRequest):
     def schedule(self) -> dict:
         return self.__schedule
 
-    def to_dict(self) -> typing.Dict[str, typing.Any]:
-        """Return a JSON-safe dictionary of all timer request fields."""
-        return {
-            'past_due': self.past_due,
-            'schedule_status': self.schedule_status,
-            'schedule': self.schedule,
-        }
+def to_dict(self) -> typing.Dict[str, typing.Any]:
+    """Return a JSON-safe dictionary of all timer request fields."""
+    from ._utils import _serialize_value
+
+    return {
+        'past_due': self.past_due,
+        'schedule_status': _serialize_value(self.schedule_status),
+        'schedule': _serialize_value(self.schedule),
+    }
 
 
 class TimerRequestConverter(meta.InConverter,

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -271,3 +271,49 @@ class TestCloudEventToDict(unittest.TestCase):
         )
         parsed = json.loads(evt.to_json())
         assert parsed["id"] == "ce2"
+
+
+class TestSerializableNonBreaking(unittest.TestCase):
+    """Verify that subclassing a binding ABC without implementing to_dict()
+    does not break instantiation - the error is deferred to call time."""
+
+    def _make_custom_queue_message(self):
+        """Return a minimal concrete subclass of _abc.QueueMessage that
+        implements only the pre-existing abstract surface, not to_dict()."""
+        import azure.functions._abc as azf_abc
+
+        class CustomQueueMessage(azf_abc.QueueMessage):
+            @property
+            def id(self): return "x"
+            def get_body(self): return b"body"
+            def get_json(self): return "body"
+            @property
+            def dequeue_count(self): return None
+            @property
+            def expiration_time(self): return None
+            @property
+            def insertion_time(self): return None
+            @property
+            def time_next_visible(self): return None
+            @property
+            def pop_receipt(self): return None
+
+        return CustomQueueMessage
+
+    def test_subclass_without_to_dict_can_be_instantiated(self):
+        # Must not raise TypeError at instantiation time.
+        cls = self._make_custom_queue_message()
+        msg = cls()
+        assert msg.id == "x"
+
+    def test_subclass_without_to_dict_raises_at_call_time(self):
+        cls = self._make_custom_queue_message()
+        msg = cls()
+        with self.assertRaises(NotImplementedError):
+            msg.to_dict()
+
+    def test_subclass_without_to_dict_to_json_raises_at_call_time(self):
+        cls = self._make_custom_queue_message()
+        msg = cls()
+        with self.assertRaises(NotImplementedError):
+            msg.to_json()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -284,19 +284,34 @@ class TestSerializableNonBreaking(unittest.TestCase):
 
         class CustomQueueMessage(azf_abc.QueueMessage):
             @property
-            def id(self): return "x"
-            def get_body(self): return b"body"
-            def get_json(self): return "body"
+            def id(self):
+                return "x"
+
+            def get_body(self):
+                return b"body"
+
+            def get_json(self):
+                return "body"
+
             @property
-            def dequeue_count(self): return None
+            def dequeue_count(self):
+                return None
+
             @property
-            def expiration_time(self): return None
+            def expiration_time(self):
+                return None
+
             @property
-            def insertion_time(self): return None
+            def insertion_time(self):
+                return None
+
             @property
-            def time_next_visible(self): return None
+            def time_next_visible(self):
+                return None
+
             @property
-            def pop_receipt(self): return None
+            def pop_receipt(self):
+                return None
 
         return CustomQueueMessage
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,273 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""Tests for the uniform to_dict() / to_json() serialization contract."""
+
+import base64
+import datetime
+import json
+import unittest
+
+import azure.functions as func
+from azure.functions._utils import _serialize_value
+
+
+class TestSerializeValue(unittest.TestCase):
+    def test_bytes_utf8(self):
+        assert _serialize_value(b"hello") == "hello"
+
+    def test_bytes_non_utf8(self):
+        raw = bytes([0xFF, 0xFE])
+        result = _serialize_value(raw)
+        assert result == {
+            "__encoding": "base64",
+            "value": base64.b64encode(raw).decode("ascii"),
+        }
+
+    def test_datetime(self):
+        dt = datetime.datetime(2024, 1, 15, 12, 30, 0)
+        assert _serialize_value(dt) == "2024-01-15T12:30:00"
+
+    def test_timedelta(self):
+        td = datetime.timedelta(hours=1, minutes=30)
+        result = _serialize_value(td)
+        assert isinstance(result, str)
+        assert "1:30:00" in result
+
+    def test_passthrough_str(self):
+        assert _serialize_value("hello") == "hello"
+
+    def test_passthrough_int(self):
+        assert _serialize_value(42) == 42
+
+    def test_passthrough_none(self):
+        assert _serialize_value(None) is None
+
+
+class TestQueueMessageToDict(unittest.TestCase):
+    def test_to_dict_defaults(self):
+        msg = func.QueueMessage()
+        d = msg.to_dict()
+        assert d["id"] is None
+        assert d["body"] == ""  # b"" decodes to ""
+        assert d["pop_receipt"] is None
+        assert d["dequeue_count"] is None
+
+    def test_to_dict_with_body(self):
+        msg = func.QueueMessage(id="abc", body=b"hello")
+        d = msg.to_dict()
+        assert d["id"] == "abc"
+        assert d["body"] == "hello"
+
+    def test_to_dict_bytes_body_non_utf8(self):
+        raw = bytes([0xFF, 0xFE])
+        msg = func.QueueMessage(body=raw)
+        d = msg.to_dict()
+        assert d["body"]["__encoding"] == "base64"
+
+    def test_to_json_returns_string(self):
+        msg = func.QueueMessage(id="x", body=b"data")
+        s = msg.to_json()
+        assert isinstance(s, str)
+        parsed = json.loads(s)
+        assert parsed["id"] == "x"
+        assert parsed["body"] == "data"
+
+
+class TestEventHubEventToDict(unittest.TestCase):
+    def test_to_dict_basic(self):
+        from azure.functions._eventhub import EventHubEvent
+        evt = EventHubEvent(
+            body=b"payload",
+            partition_key="pk1",
+            sequence_number=42,
+            offset="100",
+            enqueued_time=datetime.datetime(2024, 6, 1, 10, 0, 0),
+        )
+        d = evt.to_dict()
+        assert d["body"] == "payload"
+        assert d["partition_key"] == "pk1"
+        assert d["sequence_number"] == 42
+        assert d["offset"] == "100"
+        assert d["enqueued_time"] == "2024-06-01T10:00:00"
+        assert d["iothub_metadata"] is None
+
+    def test_to_json_roundtrip(self):
+        from azure.functions._eventhub import EventHubEvent
+        evt = EventHubEvent(body=b"test", partition_key="pk")
+        parsed = json.loads(evt.to_json())
+        assert parsed["body"] == "test"
+        assert parsed["partition_key"] == "pk"
+
+
+class TestEventGridEventToDict(unittest.TestCase):
+    def test_to_dict(self):
+        evt = func.EventGridEvent(
+            id="evt1",
+            data={"key": "val"},
+            topic="/subscriptions/sub/providers/Microsoft.Storage",
+            subject="/blobServices/default/containers/test",
+            event_type="Microsoft.Storage.BlobCreated",
+            event_time=datetime.datetime(2024, 1, 1, 0, 0, 0),
+            data_version="1.0",
+        )
+        d = evt.to_dict()
+        assert d["id"] == "evt1"
+        assert d["topic"].startswith("/subscriptions")
+        assert d["event_time"] == "2024-01-01T00:00:00"
+        assert d["data"] == {"key": "val"}
+
+    def test_to_json(self):
+        evt = func.EventGridEvent(
+            id="e2",
+            data={},
+            topic="t",
+            subject="s",
+            event_type="et",
+            event_time=None,
+            data_version="1",
+        )
+        parsed = json.loads(evt.to_json())
+        assert parsed["id"] == "e2"
+        assert parsed["event_time"] is None
+
+
+class TestServiceBusMessageToDict(unittest.TestCase):
+    def test_stub_to_dict(self):
+        # The stub base class (_servicebus.ServiceBusMessage) also has to_dict
+        msg = func.ServiceBusMessage(body=b"hello")
+        d = msg.to_dict()
+        assert d["body"] == "hello"
+        assert d["message_id"] == ""  # stub default
+
+    def test_to_json(self):
+        msg = func.ServiceBusMessage(body=b"msg")
+        parsed = json.loads(msg.to_json())
+        assert parsed["body"] == "msg"
+
+
+class TestTimerRequestToDict(unittest.TestCase):
+    def test_base_timer_to_dict(self):
+        # The base _timer.TimerRequest
+        timer = func.TimerRequest(past_due=True)
+        d = timer.to_dict()
+        assert d["past_due"] is True
+
+    def test_to_json(self):
+        timer = func.TimerRequest()
+        parsed = json.loads(timer.to_json())
+        assert parsed["past_due"] is False
+
+
+class TestInputStreamToDict(unittest.TestCase):
+    def test_base_blob_to_dict(self):
+        blob = func.InputStream(name="myblob", uri="https://x/blob", length=42)
+        d = blob.to_dict()
+        assert d["name"] == "myblob"
+        assert d["uri"] == "https://x/blob"
+        assert d["length"] == 42
+
+    def test_to_json(self):
+        blob = func.InputStream(name="b", uri="u", length=10)
+        parsed = json.loads(blob.to_json())
+        assert parsed["name"] == "b"
+
+
+class TestDocumentToDict(unittest.TestCase):
+    def test_document_to_dict(self):
+        doc = func.Document.from_dict({"id": "1", "value": 42})
+        d = doc.to_dict()
+        assert d == {"id": "1", "value": 42}
+
+    def test_document_list_to_dict(self):
+        dl = func.DocumentList()
+        dl.append(func.Document.from_dict({"a": 1}))
+        dl.append(func.Document.from_dict({"b": 2}))
+        result = dl.to_dict()
+        assert result == [{"a": 1}, {"b": 2}]
+
+    def test_document_list_to_json(self):
+        dl = func.DocumentList()
+        dl.append(func.Document.from_dict({"x": 10}))
+        parsed = json.loads(dl.to_json())
+        assert parsed == [{"x": 10}]
+
+
+class TestSqlRowToDict(unittest.TestCase):
+    def test_sql_row_to_dict(self):
+        row = func.SqlRow.from_dict({"col1": "a", "col2": 1})
+        assert row.to_dict() == {"col1": "a", "col2": 1}
+
+    def test_sql_row_list_to_dict(self):
+        rl = func.SqlRowList()
+        rl.append(func.SqlRow.from_dict({"k": "v"}))
+        assert rl.to_dict() == [{"k": "v"}]
+
+    def test_sql_row_list_to_json(self):
+        rl = func.SqlRowList()
+        rl.append(func.SqlRow.from_dict({"n": 7}))
+        parsed = json.loads(rl.to_json())
+        assert parsed == [{"n": 7}]
+
+
+class TestMySqlRowToDict(unittest.TestCase):
+    def test_mysql_row_to_dict(self):
+        row = func.MySqlRow.from_dict({"col": "val"})
+        assert row.to_dict() == {"col": "val"}
+
+    def test_mysql_row_list_to_dict(self):
+        rl = func.MySqlRowList()
+        rl.append(func.MySqlRow.from_dict({"x": 5}))
+        assert rl.to_dict() == [{"x": 5}]
+
+    def test_mysql_row_list_to_json(self):
+        rl = func.MySqlRowList()
+        rl.append(func.MySqlRow.from_dict({"y": 9}))
+        parsed = json.loads(rl.to_json())
+        assert parsed == [{"y": 9}]
+
+
+class TestKafkaEventToDict(unittest.TestCase):
+    def test_to_dict(self):
+        from azure.functions.kafka import KafkaEvent
+        evt = KafkaEvent(
+            body=b"message",
+            key="key1",
+            offset=5,
+            partition=0,
+            topic="my-topic",
+            timestamp="2024-01-01T00:00:00",
+        )
+        d = evt.to_dict()
+        assert d["body"] == "message"
+        assert d["key"] == "key1"
+        assert d["topic"] == "my-topic"
+
+    def test_to_json(self):
+        from azure.functions.kafka import KafkaEvent
+        evt = KafkaEvent(body=b"k", topic="t", key="k1", offset=0, partition=1,
+                         timestamp="ts")
+        parsed = json.loads(evt.to_json())
+        assert parsed["body"] == "k"
+
+
+class TestCloudEventToDict(unittest.TestCase):
+    def test_to_dict(self):
+        evt = func.CloudEvent(
+            id="ce1",
+            source="https://example.com/source",
+            type="com.example.someevent",
+            specversion="1.0",
+            data={"key": "value"},
+            time=datetime.datetime(2024, 3, 1, 12, 0, 0),
+        )
+        d = evt.to_dict()
+        assert d["id"] == "ce1"
+        assert d["time"] == "2024-03-01T12:00:00"
+        assert d["data"] == {"key": "value"}
+
+    def test_to_json(self):
+        evt = func.CloudEvent(
+            id="ce2", source="s", type="t", specversion="1.0", data=None
+        )
+        parsed = json.loads(evt.to_json())
+        assert parsed["id"] == "ce2"


### PR DESCRIPTION
fixes: https://github.com/Azure/azure-functions-python-library/issues/351 - add uniform `to_dict()` / `to_json()` serialization contract to all binding types

Binding objects had four inconsistent conventions for serialization — `to_dict()` (CosmosDB only), `to_json()` returning `str` (SQL/MySQL rows), `get_json()` returning payload only (EventGrid, Queue), `get_body()` returning raw bytes (ServiceBus, EventHub, Kafka), or nothing at all (Blob, Timer). `str(obj)` fell back to an unusable Python repr that silently dropped the payload.

**Changes**
- New `Serializable` mixin in `_abc.py` - abstract `to_dict() -> Any` with a concrete `to_json() -> str` that delegates to it. All binding ABCs now inherit from it.
- New `_serialize_value` helper in `_utils.py` - normalizes field values for JSON safety:
   - `bytes` - decoded as UTF-8 when valid, else `{"__encoding": "base64", "value": "..."}`
   - `datetime` / `date` - ISO-8601 string
   - `timedelta` - `str()`
   - everything else passes through unchanged
- `to_dict()` added to all concrete binding types:

| Type | Fields included |
|---|---|
| `InputStream` | `name`, `uri`, `length`, `blob_properties`, `metadata` (no body read) |
| `QueueMessage` | all envelope fields + `body` |
| `ServiceBusMessage` | all ~25 envelope fields + `body` |
| `EventGridEvent` / `EventGridOutputEvent` / `CloudEvent` | all envelope fields + `data` |
| `EventHubEvent` | `body`, `partition_key`, `sequence_number`, `offset`, `enqueued_time`, `iothub_metadata` |
| `KafkaEvent` | `body`, `key`, `offset`, `partition`, `topic`, `timestamp`, `headers` |
| `DocumentList` | list of `doc.to_dict()` |
| `SqlRow` / `MySqlRow` | `dict(self)` (additive - `to_json()` was already present) |
| `SqlRowList` / `MySqlRowList` | list of `row.to_dict()` + `to_json()` |
| `TimerRequest` | `past_due`, `schedule_status`, `schedule` |

**Non-breaking** - additive only. No existing methods renamed or removed. `get_body()` & `get_json()` are unchanged.