### PR TITLE
build: route Python installs through CFS

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -48,5 +48,3 @@ extends:
         dependsOn: Build
         jobs:
           - template: /eng/templates/jobs/ci-tests.yml@self
-            parameters:
-              artifactFeed: 'internal/PythonSDK_Internal_PublicPackages'

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -48,5 +48,3 @@ extends:
         dependsOn: Build
         jobs:
           - template: /eng/templates/jobs/ci-tests.yml@self
-            parameters:
-              artifactFeed: 'public/PythonSDK_PublicPackages'

--- a/eng/templates/jobs/build.yml
+++ b/eng/templates/jobs/build.yml
@@ -16,16 +16,17 @@ jobs:
           PYTHON_VERSION: '3.14'
           
     steps:
+      - task: PipAuthenticate@1
+        displayName: 'Authenticate to CFS'
+        inputs:
+          artifactFeeds: 'public/upstream-public'
+          onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:
           versionSpec: $(PYTHON_VERSION)
       - bash: |
           python --version
         displayName: 'Check python version'
-      - task: PipAuthenticate@1
-        displayName: 'Pip Authenticate'
-        inputs:
-          artifactFeeds: 'public/PythonSDK_PublicPackages'
       - bash: |
           python -m pip install -U pip
           python -m pip install build

--- a/eng/templates/jobs/ci-tests.yml
+++ b/eng/templates/jobs/ci-tests.yml
@@ -1,7 +1,3 @@
-parameters:
-  - name: artifactFeed
-    type: string
-
 jobs:
   - job: "TestPython"
     displayName: "Run Python SDK Unit Tests"
@@ -20,6 +16,11 @@ jobs:
           PYTHON_VERSION: '3.14'
           
     steps:
+      - task: PipAuthenticate@1
+        displayName: 'Authenticate to CFS'
+        inputs:
+          artifactFeeds: 'public/upstream-public'
+          onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:
           versionSpec: $(PYTHON_VERSION)
@@ -27,10 +28,6 @@ jobs:
           VERSION=$(python -c "import re; content = open('azure/functions/__init__.py').read(); match = re.search(r\"__version__ = '(\d+)\.(\d+)\.(\d+).*'\", content); print(match.group(1)) if match else '1'")
           echo "##vso[task.setvariable variable=MAJOR_VERSION]$VERSION"
         displayName: 'Detect package version'
-      - task: PipAuthenticate@1
-        displayName: 'Pip Authenticate'
-        inputs:
-          artifactFeeds: ${{ parameters.artifactFeed }}
       - bash: |
           PYTHON_MAJOR=$(echo $(PYTHON_VERSION) | cut -d. -f1)
           PYTHON_MINOR=$(echo $(PYTHON_VERSION) | cut -d. -f2)

--- a/eng/templates/official/jobs/build-artifacts.yml
+++ b/eng/templates/official/jobs/build-artifacts.yml
@@ -15,16 +15,17 @@ jobs:
           artifactName: "azure-functions"
 
     steps:
+      - task: PipAuthenticate@1
+        displayName: 'Authenticate to CFS'
+        inputs:
+          artifactFeeds: 'public/upstream-public'
+          onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:
           versionSpec: "3.11"
       - bash: |
           python --version
         displayName: 'Check python version'
-      - task: PipAuthenticate@1
-        displayName: 'Pip Authenticate'
-        inputs:
-          artifactFeeds: 'internal/PythonSDK_Internal_PublicPackages'
       - bash: |
           python -m pip install -U pip
           python -m pip install build

--- a/eng/templates/official/release/build-artifacts.yml
+++ b/eng/templates/official/release/build-artifacts.yml
@@ -56,16 +56,17 @@ jobs:
               "https://$(GithubUser):$(GithubPat)@github.com/${{ parameters.githubOrg }}/${{ parameters.githubRepo }}.git" .
           displayName: 'Checkout ${{ parameters.releaseBranchPrefix }}/${{ parameters.libraryVersion }} branch'
 
+      - task: PipAuthenticate@1
+        displayName: 'Authenticate to CFS'
+        inputs:
+          artifactFeeds: 'public/upstream-public'
+          onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:
           versionSpec: "${{ parameters.pythonVersion }}"
       - bash: |
           python --version
         displayName: 'Check python version'
-      - task: PipAuthenticate@1
-        displayName: 'Pip Authenticate'
-        inputs:
-          artifactFeeds: 'internal/PythonSDK_Internal_PublicPackages'
       - bash: |
           python -m pip install -U pip
           python -m pip install build


### PR DESCRIPTION
## Summary

- route every repository-owned Python install job through the `azfunc/public/upstream-public` CFS feed
- authenticate before `UsePythonVersion` with a single authoritative index (`onlyAddExtraIndex: false`)
- remove the legacy public/internal Python feed parameter from the shared test template and its callers

## Surface audit

The repository owns one Python package and four install-capable Azure DevOps job templates:

- `eng/templates/jobs/build.yml`
- `eng/templates/jobs/ci-tests.yml`
- `eng/templates/official/jobs/build-artifacts.yml`
- `eng/templates/official/release/build-artifacts.yml`

No repository-owned npm, NuGet/.NET, uv, Docker, detached helper, or customer sample/template install path applies. No pip configuration is committed.

## Validation

- Parsed all changed YAML and structurally verified each install-capable template has exactly one `PipAuthenticate@1`, targeting `public/upstream-public` with `onlyAddExtraIndex: false`, before `UsePythonVersion@0`.
- Built the wheel and sdist through CFS from an isolated Python 3.13 environment and empty pip cache in a path containing spaces.
- Ran `pip-audit .`: no known vulnerabilities found.
- Proved binary-wheel availability with a separate empty cache per case:
  - Windows build graph: CPython 3.10, 3.11, 3.12, 3.13, and 3.14 (31 wheels each)
  - Windows test graph: CPython 3.13 and 3.14 (76 wheels each)
  - Linux release graph: CPython 3.11 and 3.13 (31 wheels each)
- One initially uncached Windows CPython 3.12 wheel returned the expected anonymous CFS ingestion 401. An enrolled identity ingested it without an exception; a final anonymous cold-cache replay of all nine cases then passed.
- Verbose request evidence contained 190 HTTPS connections, all to `pkgs.dev.azure.com` or Azure Artifacts `*.vsblob.vsassets.io` storage; no request reached PyPI or pythonhosted.org.
- Audited wheel/sdist contents and the workspace artifact surface: no feed config files, credentials, lockfiles, or `node_modules` were included.

## Baseline blocker

The CFS pipeline migration itself is healthy: all five build jobs, dependency installation, authentication, and SDL checks passed. Python 3.13/3.14 tests resolve the newly released `mcp==2.0.0` and fail 11 MCP tests because MCP 2 moved SDK types from `mcp.types` to `mcp_types._types`.

This is confirmed as an unchanged baseline issue:

- this PR SHA changes only the six pipeline YAML files; `pyproject.toml`, `azure/`, and `tests/` are byte-identical to `dev`
- a detached archive of exact upstream `dev@baf7256701db19bbce9e90f657614a555c0e4c39`, installed from a new CFS-only cache, independently resolved `mcp==2.0.0` and reproduced exactly `11 failed, 875 passed, 2 skipped`, with all failures in `tests/decorators/test_mcp.py`
- the Azure Python 3.13 and 3.14 job logs show the same MCP version and identical 11-test failure set

No MCP pin, downgrade, or unrelated SDK adaptation is included in this CFS PR.