### PR TITLE
build: remove pip audit

### DIFF
--- a/eng/templates/jobs/build.yml
+++ b/eng/templates/jobs/build.yml
@@ -32,8 +32,3 @@ jobs:
           python -m pip install build
           python -m build
         displayName: 'Build Python SDK for $(PYTHON_VERSION)'
-      - bash: |
-          pip install pip-audit
-          pip-audit .
-        displayName: 'Run vulnerability scan'
-        condition: ne(variables['PYTHON_VERSION'], '3.7')

--- a/eng/templates/official/jobs/build-artifacts.yml
+++ b/eng/templates/official/jobs/build-artifacts.yml
@@ -31,7 +31,3 @@ jobs:
           python -m pip install build
           python -m build
         displayName: 'Build Python SDK'
-      - bash: |
-          pip install pip-audit
-          pip-audit .
-        displayName: 'Run vulnerability scan'


### PR DESCRIPTION
Remove `pip-audit .` call from all pipelines to reach CFS compliancy.

Example run: https://azfunc.visualstudio.com/public/_build/results?buildId=295335&view=logs&j=26946872-ec6f-5aab-fea8-cd9465ef56d1&t=cb3e8915-5f0c-5ced-ffb4-dc25961c036e