### PR TITLE
build: add Component Governance support

### DIFF
--- a/eng/ci/library-release.yml
+++ b/eng/ci/library-release.yml
@@ -32,6 +32,11 @@ extends:
       name: 1es-pool-azfunc
       image: 1es-windows-2022
       os: windows
+    sdl:
+      componentgovernance:
+        alertWarningLevel: Medium
+        failOnAlert: true
+        verbosity: Normal
 
     stages:
       - stage: ReleaseV1_BumpVersion

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -38,6 +38,11 @@ extends:
       name: 1es-pool-azfunc
       image: 1es-windows-2022
       os: windows
+    sdl:
+      componentgovernance:
+        alertWarningLevel: Medium
+        failOnAlert: true
+        verbosity: Normal
 
     stages:
       - stage: Build

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -36,6 +36,10 @@ extends:
          compiled:
            enabled: true # still only runs for default branch
          runSourceLanguagesInSourceAnalysis: true
+      componentgovernance:
+        alertWarningLevel: Medium
+        failOnAlert: true
+        verbosity: Normal
     settings:
       skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
 

--- a/eng/templates/jobs/build.yml
+++ b/eng/templates/jobs/build.yml
@@ -32,3 +32,4 @@ jobs:
           python -m pip install build
           python -m build
         displayName: 'Build Python SDK for $(PYTHON_VERSION)'
+      - template: /eng/templates/steps/generate-component-governance-requirements.yml@self

--- a/eng/templates/jobs/build.yml
+++ b/eng/templates/jobs/build.yml
@@ -4,6 +4,8 @@ jobs:
 
     strategy:
       matrix:
+        Python37:
+          PYTHON_VERSION: '3.7'
         Python310:
           PYTHON_VERSION: '3.10'
         Python311:

--- a/eng/templates/jobs/build.yml
+++ b/eng/templates/jobs/build.yml
@@ -4,8 +4,6 @@ jobs:
 
     strategy:
       matrix:
-        Python37:
-          PYTHON_VERSION: '3.7'
         Python310:
           PYTHON_VERSION: '3.10'
         Python311:

--- a/eng/templates/official/jobs/build-artifacts.yml
+++ b/eng/templates/official/jobs/build-artifacts.yml
@@ -31,3 +31,4 @@ jobs:
           python -m pip install build
           python -m build
         displayName: 'Build Python SDK'
+      - template: /eng/templates/steps/generate-component-governance-requirements.yml@self

--- a/eng/templates/official/release/build-artifacts.yml
+++ b/eng/templates/official/release/build-artifacts.yml
@@ -73,3 +73,6 @@ jobs:
           cd ${{ parameters.projectDirectory }}
           python -m build
         displayName: 'Build ${{ parameters.projectDisplayName }}'
+      - template: /eng/templates/steps/generate-component-governance-requirements.yml@self
+        parameters:
+          projectDirectory: ${{ parameters.projectDirectory }}

--- a/eng/templates/steps/generate-component-governance-requirements.yml
+++ b/eng/templates/steps/generate-component-governance-requirements.yml
@@ -1,0 +1,39 @@
+parameters:
+  - name: projectDirectory
+    type: string
+    default: '.'
+
+steps:
+  - bash: |
+      if ! python -c "import tomllib" 2>/dev/null; then
+        python -m pip install tomli
+      fi
+
+      python - <<'PY'
+      from pathlib import Path
+
+      try:
+          import tomllib
+      except ModuleNotFoundError:
+          import tomli as tomllib
+
+      pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+      optional_dependencies = pyproject["project"].get("optional-dependencies", {})
+      requirements = [
+          *pyproject["build-system"].get("requires", []),
+          *pyproject["project"].get("dependencies", []),
+          *(
+              dependency
+              for group in optional_dependencies.values()
+              for dependency in group
+          ),
+      ]
+      requirements = list(dict.fromkeys(requirements))
+      Path("requirements.txt").write_text(
+          "\n".join(requirements) + "\n",
+          encoding="utf-8",
+      )
+      print(f"Generated requirements.txt with {len(requirements)} direct dependencies")
+      PY
+    displayName: 'Generate Component Governance requirements'
+    workingDirectory: $(Build.SourcesDirectory)/${{ parameters.projectDirectory }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     'Development Status :: 5 - Production/Stable',
 ]
 dependencies = [
-    "protobuf~=4.25.3",
     'werkzeug~=3.1.3; python_version >= "3.9"',
     'werkzeug~=3.0.6; python_version == "3.8"',
     'werkzeug; python_version < "3.8"'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     'Development Status :: 5 - Production/Stable',
 ]
 dependencies = [
-    "protobuf~=4.25.3; python_version < '3.13'",
+    "protobuf~=4.25.3",
     'werkzeug~=3.1.3; python_version >= "3.9"',
     'werkzeug~=3.0.6; python_version == "3.8"',
     'werkzeug; python_version < "3.8"'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     'Development Status :: 5 - Production/Stable',
 ]
 dependencies = [
+    "protobuf~=4.25.3; python_version < '3.13'",
     'werkzeug~=3.1.3; python_version >= "3.9"',
     'werkzeug~=3.0.6; python_version == "3.8"',
     'werkzeug; python_version < "3.8"'


### PR DESCRIPTION
- Generates a temporary `requirements.txt` from `pyproject.toml`, allowing Component Governance to scan Python dependencies without maintaining duplicate manifests
- Configures Component Governance to fail the pipeline when a medium-or-higher vulnerability is identified.